### PR TITLE
Migrate Equinoxes and Solstices logic to `International` holiday group

### DIFF
--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -11,9 +11,8 @@
 #  License: MIT (see LICENSE file)
 
 from gettext import gettext as tr
-from typing import Tuple
 
-from holidays.calendars.gregorian import JUN, SEP, DEC
+from holidays.calendars.gregorian import SEP, DEC
 from holidays.constants import BANK, PUBLIC
 from holidays.groups import ChristianHolidays, InternationalHolidays, StaticHolidays
 from holidays.observed_holiday_base import (
@@ -129,7 +128,7 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
             if self._year == 2021:
                 self._add_holiday_jun_21(name)
             else:
-                self._add_holiday(name, self._summer_solstice_date)
+                self._add_summer_solstice_day(name)
 
         if self._year <= 1967 or self._year >= 1986:
             # Saint Peter and Saint Paul.
@@ -224,15 +223,6 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
 
         if self._year >= 1956 and self._year != 1997:
             self._add_holiday_dec_31(name)
-
-    @property
-    def _summer_solstice_date(self) -> Tuple[int, int]:
-        day = 20
-        if (self._year % 4 > 1 and self._year <= 2046) or (
-            self._year % 4 > 2 and self._year <= 2075
-        ):
-            day = 21
-        return JUN, day
 
 
 class CL(Chile):

--- a/holidays/countries/hongkong.py
+++ b/holidays/countries/hongkong.py
@@ -11,7 +11,6 @@
 #  License: MIT (see LICENSE file)
 
 from datetime import date
-from typing import Tuple
 
 from holidays.calendars.gregorian import (
     JAN,
@@ -223,9 +222,7 @@ class HongKong(
         # Chinese Winter Solstice Festival.
         # 冬節.
         if WINTER_SOLSTICE in self.preferred_discretionary_holidays:
-            self._add_observed(
-                self._add_holiday("Chinese Winter Solstice Festival", self._winter_solstice_date)
-            )
+            self._add_observed(self._add_winter_solstice_day("Chinese Winter Solstice Festival"))
 
         if self._year >= 2024:
             # 聖誕節後第一個周日.
@@ -414,20 +411,6 @@ class HongKong(
                 self._add_holiday_last_mon_of_aug(name)
             else:
                 self._add_holiday_aug_30(name)
-
-    @property
-    def _winter_solstice_date(self) -> Tuple[int, int]:
-        # This approximation is reliable for 1952-2099 years.
-        if (
-            (self._year % 4 == 0 and self._year >= 1988)
-            or (self._year % 4 == 1 and self._year >= 2021)
-            or (self._year % 4 == 2 and self._year >= 2058)
-            or (self._year % 4 == 3 and self._year >= 2091)
-        ):
-            day = 21
-        else:
-            day = 22
-        return DEC, day
 
 
 class HK(HongKong):

--- a/holidays/countries/japan.py
+++ b/holidays/countries/japan.py
@@ -12,21 +12,9 @@
 
 from datetime import date
 from gettext import gettext as tr
-from typing import Set, Tuple
+from typing import Set
 
-from holidays.calendars.gregorian import (
-    FEB,
-    MAR,
-    APR,
-    MAY,
-    JUN,
-    JUL,
-    AUG,
-    SEP,
-    OCT,
-    NOV,
-    _timedelta,
-)
+from holidays.calendars.gregorian import FEB, APR, MAY, JUN, JUL, AUG, OCT, NOV, _timedelta
 from holidays.constants import BANK, PUBLIC
 from holidays.groups import InternationalHolidays, StaticHolidays
 from holidays.observed_holiday_base import ObservedHolidayBase, SUN_TO_NEXT_WORKDAY
@@ -101,7 +89,7 @@ class Japan(ObservedHolidayBase, InternationalHolidays, StaticHolidays):
             dts_observed.add(self._add_holiday_feb_23(tr("天皇誕生日")))
 
         # Vernal Equinox Day.
-        dts_observed.add(self._add_holiday(tr("春分の日"), self._vernal_equinox_date))
+        dts_observed.add(self._add_vernal_equinox_day(tr("春分の日")))
 
         # Showa Emperor's Birthday, Greenery Day or Showa Day.
         if self._year <= 1988:
@@ -163,7 +151,7 @@ class Japan(ObservedHolidayBase, InternationalHolidays, StaticHolidays):
             )
 
         # Autumnal Equinox Day.
-        dts_observed.add(self._add_holiday(tr("秋分の日"), self._autumnal_equinox_date))
+        dts_observed.add(self._add_autumnal_equinox_day(tr("秋分の日")))
 
         # Physical Education and Sports Day.
         if self._year >= 1966:
@@ -207,33 +195,6 @@ class Japan(ObservedHolidayBase, InternationalHolidays, StaticHolidays):
         self._add_new_years_day_two(name)
         self._add_new_years_day_three(name)
         self._add_new_years_eve(name)
-
-    @property
-    def _vernal_equinox_date(self) -> Tuple[int, int]:
-        day = 20
-        if (
-            (self._year % 4 == 0 and self._year <= 1956)
-            or (self._year % 4 == 1 and self._year <= 1989)
-            or (self._year % 4 == 2 and self._year <= 2022)
-            or (self._year % 4 == 3 and self._year <= 2055)
-        ):
-            day = 21
-        elif self._year % 4 == 0 and self._year >= 2092:
-            day = 19
-        return MAR, day
-
-    @property
-    def _autumnal_equinox_date(self) -> Tuple[int, int]:
-        day = 23
-        if self._year % 4 == 3 and self._year <= 1979:
-            day = 24
-        elif (
-            (self._year % 4 == 0 and self._year >= 2012)
-            or (self._year % 4 == 1 and self._year >= 2045)
-            or (self._year % 4 == 2 and self._year >= 2078)
-        ):
-            day = 22
-        return SEP, day
 
 
 class JP(Japan):

--- a/holidays/groups/international.py
+++ b/holidays/groups/international.py
@@ -12,7 +12,7 @@
 
 from datetime import date
 
-from holidays.calendars.gregorian import JAN
+from holidays.calendars.gregorian import JAN, MAR, JUN, SEP, DEC
 
 
 class InternationalHolidays:
@@ -21,11 +21,98 @@ class InternationalHolidays:
     """
 
     @property
+    def _vernal_equinox_date(self):
+        """
+        Return Vernal Equinox date.
+        """
+        day = 20
+        if (
+            (self._year % 4 == 0 and self._year <= 1956)
+            or (self._year % 4 == 1 and self._year <= 1989)
+            or (self._year % 4 == 2 and self._year <= 2022)
+            or (self._year % 4 == 3 and self._year <= 2055)
+        ):
+            day = 21
+        elif self._year % 4 == 0 and self._year >= 2092:
+            day = 19
+        return date(self._year, MAR, day)
+
+    @property
+    def _summer_solstice_date(self):
+        """
+        Return Summer Solstice date.
+        """
+        # This approximation is reliable for 1952-2099 years.
+        day = 20
+        if (self._year % 4 > 1 and self._year <= 2046) or (
+            self._year % 4 > 2 and self._year <= 2075
+        ):
+            day = 21
+        return date(self._year, JUN, day)
+
+    @property
+    def _autumnal_equinox_date(self):
+        """
+        Return Autumnal Equinox date.
+        """
+        day = 23
+        if self._year % 4 == 3 and self._year <= 1979:
+            day = 24
+        elif (
+            (self._year % 4 == 0 and self._year >= 2012)
+            or (self._year % 4 == 1 and self._year >= 2045)
+            or (self._year % 4 == 2 and self._year >= 2078)
+        ):
+            day = 22
+        return date(self._year, SEP, day)
+
+    @property
+    def _winter_solstice_date(self):
+        """
+        Return Winter Solstice date.
+        """
+        # This approximation is reliable for 1952-2099 years.
+        if (
+            (self._year % 4 == 0 and self._year >= 1988)
+            or (self._year % 4 == 1 and self._year >= 2021)
+            or (self._year % 4 == 2 and self._year >= 2058)
+            or (self._year % 4 == 3 and self._year >= 2091)
+        ):
+            day = 21
+        else:
+            day = 22
+        return date(self._year, DEC, day)
+
+    @property
     def _next_year_new_years_day(self):
         """
         Return New Year's Day of next year.
         """
         return date(self._year + 1, JAN, 1)
+
+    def _add_vernal_equinox_day(self, name):
+        """
+        Add Vernal Equinox
+        """
+        return self._add_holiday(name, self._vernal_equinox_date)
+
+    def _add_summer_solstice_day(self, name):
+        """
+        Add Summer Solstice
+        """
+        return self._add_holiday(name, self._summer_solstice_date)
+
+    def _add_autumnal_equinox_day(self, name):
+        """
+        Add Autumnal Equinox
+        """
+        return self._add_holiday(name, self._autumnal_equinox_date)
+
+    def _add_winter_solstice_day(self, name):
+        """
+        Add Winter Solstice
+        """
+        return self._add_holiday(name, self._winter_solstice_date)
 
     def _add_africa_day(self, name):
         """


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This PR migrates the existing `Vernal Equinox,` `Summer Solstice,` `Autumnal Equinox,` and `Winter Solstice` implementation logic to the common `International` holidays group, hopefully, reducing code redundancy for future holiday additions.

(Done in preparation for future #784 implementations i.e. Zurich's historic "Sechseläuten" cases from 1902-1951)

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
