### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -72,7 +72,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
     -   id: pyupgrade
         args:
-          - --py38-plus
+          - --py39-plus
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.9

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,7 +72,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns: List[str] = []
+exclude_patterns: list[str] = []
 
 # Add any paths that contain templates here, relative to this directory.
 #
@@ -144,7 +144,7 @@ html_copy_source = False
 #
 # See https://sphinx-rtd-theme.readthedocs.io/en/latest/configuring.html
 #
-html_theme_options: Dict[str, Union[str, bool, int]] = {
+html_theme_options: dict[str, Union[str, bool, int]] = {
     # 'canonical_url': '',
     # 'analytics_id': 'UA-XXXXXXX-1',  #  Provided by Google in your dashboard
     # 'analytics_anonymize_ip': False

--- a/holidays/calendars/buddhist.py
+++ b/holidays/calendars/buddhist.py
@@ -11,7 +11,7 @@
 #  License: MIT (see LICENSE file)
 
 from datetime import date
-from typing import Optional, Tuple
+from typing import Optional
 
 from holidays.calendars.custom import _CustomCalendar
 from holidays.calendars.gregorian import MAY, JUN
@@ -425,16 +425,16 @@ class _BuddhistLunisolar:
         2099: (MAY, 4),
     }
 
-    def _get_holiday(self, holiday: str, year: int) -> Tuple[Optional[date], bool]:
+    def _get_holiday(self, holiday: str, year: int) -> tuple[Optional[date], bool]:
         estimated_dates = getattr(self, f"{holiday}_DATES", {})
         exact_dates = getattr(self, f"{holiday}_DATES_{_CustomCalendar.CUSTOM_ATTR_POSTFIX}", {})
         dt = exact_dates.get(year, estimated_dates.get(year, ()))
         return date(year, *dt) if dt else None, year not in exact_dates
 
-    def vesak_date(self, year: int) -> Tuple[Optional[date], bool]:
+    def vesak_date(self, year: int) -> tuple[Optional[date], bool]:
         return self._get_holiday(VESAK, year)
 
-    def vesak_may_date(self, year: int) -> Tuple[Optional[date], bool]:
+    def vesak_may_date(self, year: int) -> tuple[Optional[date], bool]:
         return self._get_holiday(VESAK_MAY, year)
 
 

--- a/holidays/calendars/chinese.py
+++ b/holidays/calendars/chinese.py
@@ -11,7 +11,7 @@
 #  License: MIT (see LICENSE file)
 
 from datetime import date
-from typing import Optional, Tuple
+from typing import Optional
 
 from holidays.calendars.custom import _CustomCalendar
 from holidays.calendars.gregorian import JAN, FEB, MAR, APR, MAY, JUN, SEP, OCT, NOV
@@ -1237,28 +1237,28 @@ class _ChineseLunisolar:
         2099: (SEP, 29),
     }
 
-    def _get_holiday(self, holiday: str, year: int) -> Tuple[Optional[date], bool]:
+    def _get_holiday(self, holiday: str, year: int) -> tuple[Optional[date], bool]:
         estimated_dates = getattr(self, f"{holiday}_DATES", {})
         exact_dates = getattr(self, f"{holiday}_DATES_{_CustomCalendar.CUSTOM_ATTR_POSTFIX}", {})
         dt = exact_dates.get(year, estimated_dates.get(year, ()))
         return date(year, *dt) if dt else None, year not in exact_dates
 
-    def buddha_birthday_date(self, year: int) -> Tuple[Optional[date], bool]:
+    def buddha_birthday_date(self, year: int) -> tuple[Optional[date], bool]:
         return self._get_holiday(BUDDHA_BIRTHDAY, year)
 
-    def double_ninth_date(self, year: int) -> Tuple[Optional[date], bool]:
+    def double_ninth_date(self, year: int) -> tuple[Optional[date], bool]:
         return self._get_holiday(DOUBLE_NINTH, year)
 
-    def dragon_boat_date(self, year: int) -> Tuple[Optional[date], bool]:
+    def dragon_boat_date(self, year: int) -> tuple[Optional[date], bool]:
         return self._get_holiday(DRAGON_BOAT, year)
 
-    def hung_kings_date(self, year: int) -> Tuple[Optional[date], bool]:
+    def hung_kings_date(self, year: int) -> tuple[Optional[date], bool]:
         return self._get_holiday(HUNG_KINGS, year)
 
-    def lunar_new_year_date(self, year: int) -> Tuple[Optional[date], bool]:
+    def lunar_new_year_date(self, year: int) -> tuple[Optional[date], bool]:
         return self._get_holiday(LUNAR_NEW_YEAR, year)
 
-    def mid_autumn_date(self, year: int) -> Tuple[Optional[date], bool]:
+    def mid_autumn_date(self, year: int) -> tuple[Optional[date], bool]:
         return self._get_holiday(MID_AUTUMN, year)
 
 

--- a/holidays/calendars/hindu.py
+++ b/holidays/calendars/hindu.py
@@ -11,7 +11,7 @@
 #  License: MIT (see LICENSE file)
 
 from datetime import date
-from typing import Optional, Tuple
+from typing import Optional
 
 from holidays.calendars.custom import _CustomCalendar
 from holidays.calendars.gregorian import JAN, FEB, MAR, OCT, NOV
@@ -425,16 +425,16 @@ class _HinduLunisolar:
         2099: (JAN, 6),
     }
 
-    def _get_holiday(self, holiday: str, year: int) -> Tuple[Optional[date], bool]:
+    def _get_holiday(self, holiday: str, year: int) -> tuple[Optional[date], bool]:
         estimated_dates = getattr(self, f"{holiday}_DATES", {})
         exact_dates = getattr(self, f"{holiday}_DATES_{_CustomCalendar.CUSTOM_ATTR_POSTFIX}", {})
         dt = exact_dates.get(year, estimated_dates.get(year, ()))
         return date(year, *dt) if dt else None, year not in exact_dates
 
-    def diwali_date(self, year: int) -> Tuple[Optional[date], bool]:
+    def diwali_date(self, year: int) -> tuple[Optional[date], bool]:
         return self._get_holiday(DIWALI, year)
 
-    def thaipusam_date(self, year: int) -> Tuple[Optional[date], bool]:
+    def thaipusam_date(self, year: int) -> tuple[Optional[date], bool]:
         return self._get_holiday(THAIPUSAM, year)
 
 

--- a/holidays/calendars/islamic.py
+++ b/holidays/calendars/islamic.py
@@ -10,8 +10,8 @@
 #  Website: https://github.com/vacanza/holidays
 #  License: MIT (see LICENSE file)
 
+from collections.abc import Iterable
 from datetime import date
-from typing import Iterable, Tuple
 
 from holidays.calendars.custom import _CustomCalendar
 from holidays.calendars.gregorian import JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP, OCT, NOV, DEC
@@ -3641,80 +3641,80 @@ class _IslamicLunar:
         2076: (DEC, 5),
     }
 
-    def _get_holiday(self, holiday: str, year: int) -> Iterable[Tuple[date, bool]]:
+    def _get_holiday(self, holiday: str, year: int) -> Iterable[tuple[date, bool]]:
         estimated_dates = getattr(self, f"{holiday}_DATES", {})
         exact_dates = getattr(self, f"{holiday}_DATES_{_CustomCalendar.CUSTOM_ATTR_POSTFIX}", {})
         for year in (year - 1, year):
             for dt in _normalize_tuple(exact_dates.get(year, estimated_dates.get(year, ()))):
                 yield date(year, *dt), year not in exact_dates
 
-    def ali_al_rida_death_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def ali_al_rida_death_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(ALI_AL_RIDA_DEATH, year)
 
-    def ali_birthday_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def ali_birthday_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(ALI_BIRTHDAY, year)
 
-    def ali_death_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def ali_death_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(ALI_DEATH, year)
 
-    def arbaeen_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def arbaeen_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(ARBAEEN, year)
 
-    def ashura_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def ashura_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(ASHURA, year)
 
-    def eid_al_adha_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def eid_al_adha_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(EID_AL_ADHA, year)
 
-    def eid_al_fitr_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def eid_al_fitr_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(EID_AL_FITR, year)
 
-    def eid_al_ghadir_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def eid_al_ghadir_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(EID_AL_GHADIR, year)
 
-    def fatima_death_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def fatima_death_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(FATIMA_DEATH, year)
 
-    def hari_hol_johor_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def hari_hol_johor_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(HARI_HOL_JOHOR, year)
 
-    def hasan_al_askari_death_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def hasan_al_askari_death_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(HASAN_AL_ASKARI_DEATH, year)
 
-    def hijri_new_year_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def hijri_new_year_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(HIJRI_NEW_YEAR, year)
 
-    def imam_mahdi_birthday_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def imam_mahdi_birthday_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(IMAM_MAHDI_BIRTHDAY, year)
 
-    def isra_and_miraj_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def isra_and_miraj_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(ISRA_AND_MIRAJ, year)
 
-    def maldives_embraced_islam_day_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def maldives_embraced_islam_day_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(MALDIVES_EMBRACED_ISLAM_DAY, year)
 
-    def mawlid_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def mawlid_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(MAWLID, year)
 
-    def nuzul_al_quran_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def nuzul_al_quran_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(NUZUL_AL_QURAN, year)
 
-    def prophet_death_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def prophet_death_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(PROPHET_DEATH, year)
 
-    def quamee_dhuvas_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def quamee_dhuvas_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(QUAMEE_DHUVAS, year)
 
-    def ramadan_beginning_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def ramadan_beginning_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(RAMADAN_BEGINNING, year)
 
-    def sadiq_birthday_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def sadiq_birthday_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(SADIQ_BIRTHDAY, year)
 
-    def sadiq_death_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def sadiq_death_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(SADIQ_DEATH, year)
 
-    def tasua_dates(self, year: int) -> Iterable[Tuple[date, bool]]:
+    def tasua_dates(self, year: int) -> Iterable[tuple[date, bool]]:
         return self._get_holiday(TASUA, year)
 
 

--- a/holidays/countries/angola.py
+++ b/holidays/countries/angola.py
@@ -12,7 +12,7 @@
 
 from datetime import date
 from gettext import gettext as tr
-from typing import Optional, Tuple
+from typing import Optional
 
 from holidays.calendars.gregorian import AUG, SEP
 from holidays.groups import ChristianHolidays, InternationalHolidays, StaticHolidays
@@ -59,7 +59,7 @@ class Angola(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         # it rolls over to the following Monday.
         return dt >= date(1996, SEP, 27)
 
-    def _add_observed(self, dt: date, **kwargs) -> Tuple[bool, Optional[date]]:
+    def _add_observed(self, dt: date, **kwargs) -> tuple[bool, Optional[date]]:
         # As per Law # #11/18, from 2018/9/10, when public holiday falls on Tuesday or Thursday,
         # the Monday or Friday is also a holiday.
         kwargs.setdefault(

--- a/holidays/countries/bulgaria.py
+++ b/holidays/countries/bulgaria.py
@@ -12,7 +12,6 @@
 
 from datetime import date
 from gettext import gettext as tr
-from typing import Set
 
 from holidays.calendars.julian_revised import JULIAN_REVISED_CALENDAR
 from holidays.constants import PUBLIC, SCHOOL
@@ -57,7 +56,7 @@ class Bulgaria(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         kwargs.setdefault("observed_since", 2017)
         super().__init__(*args, **kwargs)
 
-    def _populate_observed(self, dts: Set[date], excluded_names: Set[str]) -> None:
+    def _populate_observed(self, dts: set[date], excluded_names: set[str]) -> None:
         for dt in sorted(dts):
             if not self._is_observed(dt):
                 continue

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -11,7 +11,6 @@
 #  License: MIT (see LICENSE file)
 
 from gettext import gettext as tr
-from typing import Tuple
 
 from holidays.calendars.gregorian import JUN, SEP, DEC
 from holidays.constants import BANK, PUBLIC
@@ -226,7 +225,7 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
             self._add_holiday_dec_31(name)
 
     @property
-    def _summer_solstice_date(self) -> Tuple[int, int]:
+    def _summer_solstice_date(self) -> tuple[int, int]:
         day = 20
         if (self._year % 4 > 1 and self._year <= 2046) or (
             self._year % 4 > 2 and self._year <= 2075

--- a/holidays/countries/hongkong.py
+++ b/holidays/countries/hongkong.py
@@ -11,7 +11,6 @@
 #  License: MIT (see LICENSE file)
 
 from datetime import date
-from typing import Tuple
 
 from holidays.calendars.gregorian import (
     JAN,
@@ -416,7 +415,7 @@ class HongKong(
                 self._add_holiday_aug_30(name)
 
     @property
-    def _winter_solstice_date(self) -> Tuple[int, int]:
+    def _winter_solstice_date(self) -> tuple[int, int]:
         # This approximation is reliable for 1952-2099 years.
         if (
             (self._year % 4 == 0 and self._year >= 1988)

--- a/holidays/countries/japan.py
+++ b/holidays/countries/japan.py
@@ -12,7 +12,6 @@
 
 from datetime import date
 from gettext import gettext as tr
-from typing import Set, Tuple
 
 from holidays.calendars.gregorian import (
     FEB,
@@ -54,7 +53,7 @@ class Japan(ObservedHolidayBase, InternationalHolidays, StaticHolidays):
     def _is_observed(self, dt: date) -> bool:
         return dt >= date(1973, APR, 12)
 
-    def _populate_observed(self, dts: Set[date]) -> None:
+    def _populate_observed(self, dts: set[date]) -> None:
         # When a national holiday falls on Sunday, next working day
         # shall become a public holiday (振替休日) - substitute holiday.
         for dt in sorted(dts):
@@ -211,7 +210,7 @@ class Japan(ObservedHolidayBase, InternationalHolidays, StaticHolidays):
         self._add_new_years_eve(name)
 
     @property
-    def _vernal_equinox_date(self) -> Tuple[int, int]:
+    def _vernal_equinox_date(self) -> tuple[int, int]:
         day = 20
         if (
             (self._year % 4 == 0 and self._year <= 1956)
@@ -225,7 +224,7 @@ class Japan(ObservedHolidayBase, InternationalHolidays, StaticHolidays):
         return MAR, day
 
     @property
-    def _autumnal_equinox_date(self) -> Tuple[int, int]:
+    def _autumnal_equinox_date(self) -> tuple[int, int]:
         day = 23
         if self._year % 4 == 3 and self._year <= 1979:
             day = 24

--- a/holidays/countries/jersey.py
+++ b/holidays/countries/jersey.py
@@ -11,7 +11,7 @@
 #  License: MIT (see LICENSE file)
 
 from datetime import date
-from typing import Optional, Tuple
+from typing import Optional
 
 from holidays.calendars.gregorian import JAN, APR, MAY, JUN, JUL, SEP, OCT, DEC
 from holidays.groups import ChristianHolidays, InternationalHolidays, StaticHolidays
@@ -56,7 +56,7 @@ class Jersey(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_WORKDAY)
         ObservedHolidayBase.__init__(self, *args, **kwargs)
 
-    def _add_observed(self, dt: date, **kwargs) -> Tuple[bool, Optional[date]]:
+    def _add_observed(self, dt: date, **kwargs) -> tuple[bool, Optional[date]]:
         # Prior to 2004, in-lieu are only given for Sundays.
         # https://www.jerseylaw.je/laws/enacted/Pages/RO-123-2004.aspx
         kwargs.setdefault(

--- a/holidays/countries/saudi_arabia.py
+++ b/holidays/countries/saudi_arabia.py
@@ -12,7 +12,6 @@
 
 from datetime import date
 from gettext import gettext as tr
-from typing import Set
 
 from holidays.calendars.gregorian import JAN, FEB, SEP, NOV, THU, FRI, SAT, _timedelta
 from holidays.groups import IslamicHolidays, StaticHolidays
@@ -58,7 +57,7 @@ class SaudiArabia(ObservedHolidayBase, IslamicHolidays, StaticHolidays):
         kwargs.setdefault("observed_rule", FRI_TO_PREV_THU + SAT_TO_NEXT_SUN)
         super().__init__(*args, **kwargs)
 
-    def _add_islamic_observed(self, dts: Set[date]) -> None:
+    def _add_islamic_observed(self, dts: set[date]) -> None:
         # Observed days are added to make up for any days falling on a weekend.
         if not self.observed:
             return None

--- a/holidays/countries/south_korea.py
+++ b/holidays/countries/south_korea.py
@@ -13,7 +13,6 @@
 import warnings
 from datetime import date
 from gettext import gettext as tr
-from typing import Dict, Set
 
 from holidays.calendars import _CustomChineseHolidays
 from holidays.calendars.gregorian import (
@@ -103,7 +102,7 @@ class SouthKorea(
         kwargs.setdefault("observed_since", 2014)
         super().__init__(*args, **kwargs)
 
-    def _populate_observed(self, dts: Set[date], three_day_holidays: Dict[date, str]) -> None:
+    def _populate_observed(self, dts: set[date], three_day_holidays: dict[date, str]) -> None:
         for dt in sorted(dts.union(three_day_holidays.keys())):
             if not self._is_observed(dt):
                 continue

--- a/holidays/countries/taiwan.py
+++ b/holidays/countries/taiwan.py
@@ -12,7 +12,6 @@
 
 from datetime import date
 from gettext import gettext as tr
-from typing import Set
 
 from holidays.calendars.gregorian import (
     JAN,
@@ -80,7 +79,7 @@ class Taiwan(ObservedHolidayBase, ChineseCalendarHolidays, InternationalHolidays
         super().__init__(*args, **kwargs)
 
     def _populate_observed(
-        self, dts: Set[date], rule: ObservedRule = None, since: int = 2015
+        self, dts: set[date], rule: ObservedRule = None, since: int = 2015
     ) -> None:
         if self._year < since:
             return None

--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -10,7 +10,7 @@
 #  Website: https://github.com/vacanza/holidays
 #  License: MIT (see LICENSE file)
 
-from typing import Tuple, Union
+from typing import Union
 
 from holidays.calendars.gregorian import APR, MAY, JUN, JUL, SEP, DEC
 from holidays.groups import ChristianHolidays, InternationalHolidays, StaticHolidays
@@ -38,7 +38,7 @@ class UnitedKingdom(ObservedHolidayBase, ChristianHolidays, InternationalHoliday
 
     country = "GB"
     observed_label = "%s (observed)"
-    subdivisions: Union[Tuple[()], Tuple[str, ...]] = (
+    subdivisions: Union[tuple[()], tuple[str, ...]] = (
         "ENG",  # England
         "NIR",  # Northern Ireland
         "SCT",  # Scotland

--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -10,7 +10,7 @@
 #  Website: https://github.com/vacanza/holidays
 #  License: MIT (see LICENSE file)
 
-from typing import Tuple, Union
+from typing import Union
 
 from holidays.calendars.gregorian import MON, TUE, WED, THU, FRI, SAT, SUN
 from holidays.constants import PUBLIC, UNOFFICIAL
@@ -62,7 +62,7 @@ class UnitedStates(ObservedHolidayBase, ChristianHolidays, InternationalHolidays
     country = "US"
     supported_categories = (PUBLIC, UNOFFICIAL)
     observed_label = "%s (observed)"
-    subdivisions: Union[Tuple[()], Tuple[str, ...]] = (
+    subdivisions: Union[tuple[()], tuple[str, ...]] = (
         "AK",  # Alaska.
         "AL",  # Alabama.
         "AR",  # Arkansas.

--- a/holidays/groups/buddhist.py
+++ b/holidays/groups/buddhist.py
@@ -11,7 +11,7 @@
 #  License: MIT (see LICENSE file)
 
 from datetime import date
-from typing import Optional, Tuple
+from typing import Optional
 
 from holidays.calendars import _BuddhistLunisolar
 
@@ -26,7 +26,7 @@ class BuddhistCalendarHolidays:
         self._buddhist_calendar_show_estimated = show_estimated
 
     def _add_buddhist_calendar_holiday(
-        self, name: str, dt_estimated: Tuple[date, bool]
+        self, name: str, dt_estimated: tuple[date, bool]
     ) -> Optional[date]:
         """
         Add Buddhist calendar holiday.

--- a/holidays/groups/chinese.py
+++ b/holidays/groups/chinese.py
@@ -11,7 +11,7 @@
 #  License: MIT (see LICENSE file)
 
 from datetime import date
-from typing import Optional, Tuple
+from typing import Optional
 
 from holidays.calendars import _ChineseLunisolar
 from holidays.calendars.gregorian import APR, _timedelta
@@ -48,7 +48,7 @@ class ChineseCalendarHolidays:
         return self._chinese_calendar.mid_autumn_date(self._year)[0]
 
     def _add_chinese_calendar_holiday(
-        self, name: str, dt_estimated: Tuple[date, bool], days_delta: int = 0
+        self, name: str, dt_estimated: tuple[date, bool], days_delta: int = 0
     ) -> Optional[date]:
         """
         Add Chinese calendar holiday.

--- a/holidays/groups/hindu.py
+++ b/holidays/groups/hindu.py
@@ -11,7 +11,7 @@
 #  License: MIT (see LICENSE file)
 
 from datetime import date
-from typing import Optional, Tuple
+from typing import Optional
 
 from holidays.calendars import _HinduLunisolar
 
@@ -26,7 +26,7 @@ class HinduCalendarHolidays:
         self._hindu_calendar_show_estimated = show_estimated
 
     def _add_hindu_calendar_holiday(
-        self, name: str, dt_estimated: Tuple[date, bool]
+        self, name: str, dt_estimated: tuple[date, bool]
     ) -> Optional[date]:
         """
         Add Hindu calendar holiday.

--- a/holidays/groups/islamic.py
+++ b/holidays/groups/islamic.py
@@ -10,8 +10,8 @@
 #  Website: https://github.com/vacanza/holidays
 #  License: MIT (see LICENSE file)
 
+from collections.abc import Iterable
 from datetime import date
-from typing import Iterable, Set, Tuple
 
 from holidays.calendars import _IslamicLunar
 from holidays.calendars.gregorian import _timedelta
@@ -28,7 +28,7 @@ class IslamicHolidays:
     def __init__(self, cls=None) -> None:
         self._islamic_calendar = cls() if cls else _IslamicLunar()
 
-    def _add_ali_al_rida_death_day(self, name) -> Set[date]:
+    def _add_ali_al_rida_death_day(self, name) -> set[date]:
         """
         Add death of Ali al-Rida day (last (29th or 30th) day of 2nd month).
 
@@ -38,7 +38,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.ali_al_rida_death_dates(self._year)
         )
 
-    def _add_ali_birthday_day(self, name) -> Set[date]:
+    def _add_ali_birthday_day(self, name) -> set[date]:
         """
         Add birthday of Ali ibn Abu Talib day (13th day of 7th month).
 
@@ -48,7 +48,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.ali_birthday_dates(self._year)
         )
 
-    def _add_ali_death_day(self, name) -> Set[date]:
+    def _add_ali_death_day(self, name) -> set[date]:
         """
         Add death of Ali ibn Abu Talib day (21st day of 9th month).
 
@@ -58,7 +58,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.ali_death_dates(self._year)
         )
 
-    def _add_arbaeen_day(self, name) -> Set[date]:
+    def _add_arbaeen_day(self, name) -> set[date]:
         """
         Add Arbaeen day (20th day of 2nd month).
 
@@ -68,7 +68,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.arbaeen_dates(self._year)
         )
 
-    def _add_arafah_day(self, name) -> Set[date]:
+    def _add_arafah_day(self, name) -> set[date]:
         """
         Add Day of Arafah (9th day of 12th month).
 
@@ -81,7 +81,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.eid_al_adha_dates(self._year), days_delta=-1
         )
 
-    def _add_ashura_day(self, name) -> Set[date]:
+    def _add_ashura_day(self, name) -> set[date]:
         """
         Add Ashura Day (10th day of 1st month).
 
@@ -93,7 +93,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.ashura_dates(self._year)
         )
 
-    def _add_ashura_eve(self, name) -> Set[date]:
+    def _add_ashura_eve(self, name) -> set[date]:
         """
         Add Ashura Eve (Day before the 10th day of 1st month).
 
@@ -105,7 +105,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.ashura_dates(self._year), days_delta=-1
         )
 
-    def _add_eid_al_adha_day(self, name) -> Set[date]:
+    def _add_eid_al_adha_day(self, name) -> set[date]:
         """
         Add Eid al-Adha Day (10th day of the 12th month of Islamic calendar).
 
@@ -118,7 +118,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.eid_al_adha_dates(self._year)
         )
 
-    def _add_eid_al_adha_day_two(self, name) -> Set[date]:
+    def _add_eid_al_adha_day_two(self, name) -> set[date]:
         """
         Add Eid al-Adha Day Two.
 
@@ -128,7 +128,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.eid_al_adha_dates(self._year), days_delta=+1
         )
 
-    def _add_eid_al_adha_day_three(self, name) -> Set[date]:
+    def _add_eid_al_adha_day_three(self, name) -> set[date]:
         """
         Add Eid al-Adha Day Three.
 
@@ -138,7 +138,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.eid_al_adha_dates(self._year), days_delta=+2
         )
 
-    def _add_eid_al_adha_day_four(self, name) -> Set[date]:
+    def _add_eid_al_adha_day_four(self, name) -> set[date]:
         """
         Add Eid al-Adha Day Four.
 
@@ -148,7 +148,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.eid_al_adha_dates(self._year), days_delta=+3
         )
 
-    def _add_eid_al_fitr_day(self, name) -> Set[date]:
+    def _add_eid_al_fitr_day(self, name) -> set[date]:
         """
         Add Eid al-Fitr Day (1st day of 10th month of Islamic calendar).
 
@@ -161,7 +161,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.eid_al_fitr_dates(self._year)
         )
 
-    def _add_eid_al_fitr_day_two(self, name) -> Set[date]:
+    def _add_eid_al_fitr_day_two(self, name) -> set[date]:
         """
         Add Eid al-Fitr Day Two.
 
@@ -171,7 +171,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.eid_al_fitr_dates(self._year), days_delta=+1
         )
 
-    def _add_eid_al_fitr_day_three(self, name) -> Set[date]:
+    def _add_eid_al_fitr_day_three(self, name) -> set[date]:
         """
         Add Eid al-Fitr Day Three.
 
@@ -181,7 +181,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.eid_al_fitr_dates(self._year), days_delta=+2
         )
 
-    def _add_eid_al_fitr_day_four(self, name) -> Set[date]:
+    def _add_eid_al_fitr_day_four(self, name) -> set[date]:
         """
         Add Eid al-Fitr Day Four.
 
@@ -191,7 +191,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.eid_al_fitr_dates(self._year), days_delta=+3
         )
 
-    def _add_eid_al_fitr_eve(self, name) -> Set[date]:
+    def _add_eid_al_fitr_eve(self, name) -> set[date]:
         """
         Add Eid al-Fitr Eve (last day of 9th month of Islamic calendar).
 
@@ -201,7 +201,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.eid_al_fitr_dates(self._year), days_delta=-1
         )
 
-    def _add_eid_al_ghadir_day(self, name) -> Set[date]:
+    def _add_eid_al_ghadir_day(self, name) -> set[date]:
         """
         Add Eid al-Ghadir Day (18th day of 12th month).
 
@@ -211,7 +211,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.eid_al_ghadir_dates(self._year)
         )
 
-    def _add_fatima_death_day(self, name) -> Set[date]:
+    def _add_fatima_death_day(self, name) -> set[date]:
         """
         Add death of Fatima day (3rd day of 6th month).
 
@@ -221,7 +221,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.fatima_death_dates(self._year)
         )
 
-    def _add_hari_hol_johor(self, name) -> Set[date]:
+    def _add_hari_hol_johor(self, name) -> set[date]:
         """
         Hari Hol Johor.
 
@@ -231,7 +231,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.hari_hol_johor_dates(self._year)
         )
 
-    def _add_hasan_al_askari_death_day(self, name) -> Set[date]:
+    def _add_hasan_al_askari_death_day(self, name) -> set[date]:
         """
         Add death of Hasan_al-Askari day (8th day of 3rd month).
 
@@ -241,7 +241,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.hasan_al_askari_death_dates(self._year)
         )
 
-    def _add_imam_mahdi_birthday_day(self, name) -> Set[date]:
+    def _add_imam_mahdi_birthday_day(self, name) -> set[date]:
         """
         Add birthday of Muhammad al-Mahdi day (15th day of 8th month).
 
@@ -252,8 +252,8 @@ class IslamicHolidays:
         )
 
     def _add_islamic_calendar_holiday(
-        self, name: str, dates: Iterable[Tuple[date, bool]], days_delta: int = 0
-    ) -> Set[date]:
+        self, name: str, dates: Iterable[tuple[date, bool]], days_delta: int = 0
+    ) -> set[date]:
         """
         Add lunar calendar holiday.
 
@@ -274,7 +274,7 @@ class IslamicHolidays:
 
         return added_dates
 
-    def _add_islamic_new_year_day(self, name) -> Set[date]:
+    def _add_islamic_new_year_day(self, name) -> set[date]:
         """
         Add Islamic New Year Day (last day of Dhu al-Hijjah).
 
@@ -299,7 +299,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.isra_and_miraj_dates(self._year)
         )
 
-    def _add_maldives_embraced_islam_day(self, name) -> Set[date]:
+    def _add_maldives_embraced_islam_day(self, name) -> set[date]:
         """
         Add Maldives Embraced Islam Day (1st day of 4th month).
 
@@ -309,7 +309,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.maldives_embraced_islam_day_dates(self._year)
         )
 
-    def _add_mawlid_day(self, name) -> Set[date]:
+    def _add_mawlid_day(self, name) -> set[date]:
         """
         Add Mawlid Day (12th day of 3rd month).
 
@@ -321,7 +321,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.mawlid_dates(self._year)
         )
 
-    def _add_mawlid_day_two(self, name) -> Set[date]:
+    def _add_mawlid_day_two(self, name) -> set[date]:
         """
         Add Mawlid Day Two.
 
@@ -333,7 +333,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.mawlid_dates(self._year), days_delta=+1
         )
 
-    def _add_nuzul_al_quran_day(self, name) -> Set[date]:
+    def _add_nuzul_al_quran_day(self, name) -> set[date]:
         """
         Add Nuzul Al Quran (17th day of 9th month).
 
@@ -346,7 +346,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.nuzul_al_quran_dates(self._year)
         )
 
-    def _add_prophet_death_day(self, name) -> Set[date]:
+    def _add_prophet_death_day(self, name) -> set[date]:
         """
         Add death of Prophet Muhammad and Hasan ibn Ali day (28th day of 2nd month).
 
@@ -356,7 +356,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.prophet_death_dates(self._year)
         )
 
-    def _add_quamee_dhuvas_day(self, name) -> Set[date]:
+    def _add_quamee_dhuvas_day(self, name) -> set[date]:
         """
         Add Quamee Dhuvas (1st day of 3rd month).
 
@@ -366,7 +366,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.quamee_dhuvas_dates(self._year)
         )
 
-    def _add_ramadan_beginning_day(self, name) -> Set[date]:
+    def _add_ramadan_beginning_day(self, name) -> set[date]:
         """
         Add First Day of Ramadan (1st day of 9th month).
 
@@ -378,7 +378,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.ramadan_beginning_dates(self._year)
         )
 
-    def _add_sadiq_birthday_day(self, name) -> Set[date]:
+    def _add_sadiq_birthday_day(self, name) -> set[date]:
         """
         Add birthday of Prophet Muhammad and Ja'far al-Sadiq day (17th day of 3rd month).
 
@@ -388,7 +388,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.sadiq_birthday_dates(self._year)
         )
 
-    def _add_sadiq_death_day(self, name) -> Set[date]:
+    def _add_sadiq_death_day(self, name) -> set[date]:
         """
         Add death of Ja'far al-Sadiq day (25th day of 10th month).
 
@@ -398,7 +398,7 @@ class IslamicHolidays:
             name, self._islamic_calendar.sadiq_death_dates(self._year)
         )
 
-    def _add_tasua_day(self, name) -> Set[date]:
+    def _add_tasua_day(self, name) -> set[date]:
         """
         Add Tasua day (9th day of 1st month).
 

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -15,11 +15,12 @@ __all__ = ("DateLike", "HolidayBase", "HolidaySum")
 import copy
 import warnings
 from calendar import isleap
+from collections.abc import Iterable
 from datetime import date, datetime, timedelta, timezone
 from functools import cached_property
 from gettext import gettext, translation
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union, cast
+from typing import Any, Dict, Optional, Union, cast
 
 from dateutil.parser import parse
 
@@ -42,17 +43,17 @@ from holidays.constants import HOLIDAY_NAME_DELIMITER, PUBLIC
 from holidays.helpers import _normalize_arguments, _normalize_tuple
 
 CategoryArg = Union[str, Iterable[str]]
-DateArg = Union[date, Tuple[int, int]]
+DateArg = Union[date, tuple[int, int]]
 DateLike = Union[date, datetime, str, float, int]
-SpecialHoliday = Union[Tuple[int, int, str], Tuple[Tuple[int, int, str], ...]]
+SpecialHoliday = Union[tuple[int, int, str], tuple[tuple[int, int, str], ...]]
 SubstitutedHoliday = Union[
-    Union[Tuple[int, int, int, int], Tuple[int, int, int, int, int]],
-    Tuple[Union[Tuple[int, int, int, int], Tuple[int, int, int, int, int]], ...],
+    Union[tuple[int, int, int, int], tuple[int, int, int, int, int]],
+    tuple[Union[tuple[int, int, int, int], tuple[int, int, int, int, int]], ...],
 ]
 YearArg = Union[int, Iterable[int]]
 
 
-class HolidayBase(Dict[date, str]):
+class HolidayBase(dict[date, str]):
     """
     A dict-like object containing the holidays for a specific country (and
     province or state if so initiated); inherits the dict class (so behaves
@@ -210,12 +211,12 @@ class HolidayBase(Dict[date, str]):
     """The country's ISO 3166-1 alpha-2 code."""
     market: str
     """The market's ISO 3166-1 alpha-2 code."""
-    subdivisions: Tuple[str, ...] = ()
+    subdivisions: tuple[str, ...] = ()
     """The subdivisions supported for this country (see documentation)."""
-    subdivisions_aliases: Dict[str, str] = {}
+    subdivisions_aliases: dict[str, str] = {}
     """Aliases for the ISO 3166-2 subdivision codes with the key as alias and
     the value the ISO 3166-2 subdivision code."""
-    years: Set[int]
+    years: set[int]
     """The years calculated."""
     expand: bool
     """Whether the entire year is calculated when one date from that year
@@ -224,25 +225,25 @@ class HolidayBase(Dict[date, str]):
     """Whether dates when public holiday are observed are included."""
     subdiv: Optional[str] = None
     """The subdiv requested as ISO 3166-2 code or one of the aliases."""
-    special_holidays: Dict[int, Union[SpecialHoliday, SubstitutedHoliday]] = {}
+    special_holidays: dict[int, Union[SpecialHoliday, SubstitutedHoliday]] = {}
     """A list of the country-wide special (as opposite to regular) holidays for
     a specific year."""
-    _deprecated_subdivisions: Tuple[str, ...] = ()
+    _deprecated_subdivisions: tuple[str, ...] = ()
     """Other subdivisions whose names are deprecated or aliases of the official
     ones."""
-    weekend: Set[int] = {SAT, SUN}
+    weekend: set[int] = {SAT, SUN}
     """Country weekend days."""
-    weekend_workdays: Set[date] = set()
+    weekend_workdays: set[date] = set()
     """Working days moved to weekends."""
     default_category: str = PUBLIC
     """The entity category used by default."""
     default_language: Optional[str] = None
     """The entity language used by default."""
-    categories: Set[str] = set()
+    categories: set[str] = set()
     """Requested holiday categories."""
-    supported_categories: Tuple[str, ...] = (PUBLIC,)
+    supported_categories: tuple[str, ...] = (PUBLIC,)
     """All holiday categories supported by this entity."""
-    supported_languages: Tuple[str, ...] = ()
+    supported_languages: tuple[str, ...] = ()
     """All languages supported by this entity."""
 
     def __init__(
@@ -630,7 +631,7 @@ class HolidayBase(Dict[date, str]):
     def __radd__(self, other: Any) -> "HolidayBase":
         return self.__add__(other)
 
-    def __reduce__(self) -> Union[str, Tuple[Any, ...]]:
+    def __reduce__(self) -> Union[str, tuple[Any, ...]]:
         return super().__reduce__()
 
     def __repr__(self) -> str:
@@ -720,9 +721,9 @@ class HolidayBase(Dict[date, str]):
         )
 
     @classmethod
-    def get_subdivision_aliases(cls) -> Dict[str, List]:
+    def get_subdivision_aliases(cls) -> dict[str, list]:
         """Get subdivision aliases."""
-        subdivision_aliases: Dict[str, List[str]] = {s: [] for s in cls.subdivisions}
+        subdivision_aliases: dict[str, list[str]] = {s: [] for s in cls.subdivisions}
         for alias, subdivision in cls.subdivisions_aliases.items():
             subdivision_aliases[subdivision].append(alias)
 
@@ -862,7 +863,7 @@ class HolidayBase(Dict[date, str]):
                 for category in self._sorted_categories
             )
 
-    def append(self, *args: Union[Dict[DateLike, str], List[DateLike], DateLike]) -> None:
+    def append(self, *args: Union[dict[DateLike, str], list[DateLike], DateLike]) -> None:
         """Alias for :meth:`update` to mimic list type."""
         return self.update(*args)
 
@@ -891,7 +892,7 @@ class HolidayBase(Dict[date, str]):
         """
         return dict.get(self, self.__keytransform__(key), default)
 
-    def get_list(self, key: DateLike) -> List[str]:
+    def get_list(self, key: DateLike) -> list[str]:
         """Return a list of all holiday names for a date if date is a holiday,
         else empty string.
 
@@ -909,7 +910,7 @@ class HolidayBase(Dict[date, str]):
 
     def get_named(
         self, holiday_name: str, lookup="icontains", split_multiple_names=True
-    ) -> List[date]:
+    ) -> list[date]:
         """Return a list of all holiday dates matching the provided holiday
         name. The match will be made case insensitively and partial matches
         will be included by default.
@@ -1025,7 +1026,7 @@ class HolidayBase(Dict[date, str]):
 
         return dict.pop(self, self.__keytransform__(key), default)
 
-    def pop_named(self, name: str) -> List[date]:
+    def pop_named(self, name: str) -> list[date]:
         """Remove (no longer treat at as holiday) all dates matching the
         provided holiday name. The match will be made case insensitively and
         partial matches will be removed.
@@ -1065,7 +1066,7 @@ class HolidayBase(Dict[date, str]):
         return popped
 
     def update(  # type: ignore[override]
-        self, *args: Union[Dict[DateLike, str], List[DateLike], DateLike]
+        self, *args: Union[dict[DateLike, str], list[DateLike], DateLike]
     ) -> None:
         # TODO: fix arguments; should not be *args (cannot properly Type hint)
         """Update the object, overwriting existing dates.
@@ -1105,15 +1106,15 @@ class HolidaySum(HolidayBase):
     are merged. All years are calculated (expanded) for all operands.
     """
 
-    country: Union[str, List[str]]  # type: ignore[assignment]
+    country: Union[str, list[str]]  # type: ignore[assignment]
     """Countries included in the addition."""
-    market: Union[str, List[str]]  # type: ignore[assignment]
+    market: Union[str, list[str]]  # type: ignore[assignment]
     """Markets included in the addition."""
-    subdiv: Optional[Union[str, List[str]]]  # type: ignore[assignment]
+    subdiv: Optional[Union[str, list[str]]]  # type: ignore[assignment]
     """Subdivisions included in the addition."""
-    holidays: List[HolidayBase]
+    holidays: list[HolidayBase]
     """The original HolidayBase objects included in the addition."""
-    years: Set[int]
+    years: set[int]
     """The years calculated."""
 
     def __init__(
@@ -1153,7 +1154,7 @@ country_holidays('CA') + country_holidays('MX')
             else:
                 self.holidays.append(operand)
 
-        kwargs: Dict[str, Any] = {}
+        kwargs: dict[str, Any] = {}
         # Join years, expand and observed.
         kwargs["years"] = h1.years | h2.years
         kwargs["expand"] = h1.expand or h2.expand

--- a/holidays/mixins.py
+++ b/holidays/mixins.py
@@ -11,16 +11,13 @@
 #  License: MIT (see LICENSE file)
 
 
-from typing import Tuple
-
-
 class PreferredDiscretionaryHolidays:
     """A mixin for setting preferred discretionary holidays.
 
     See :class:`holidays.countries.hongkong.HongKong` for an example.
     """
 
-    default_preferred_discretionary_holidays: Tuple[str, ...] = ()
+    default_preferred_discretionary_holidays: tuple[str, ...] = ()
     """Preferred discretionary holidays defaults."""
 
     def __init__(self, preferred_discretionary_holidays):

--- a/holidays/observed_holiday_base.py
+++ b/holidays/observed_holiday_base.py
@@ -11,13 +11,13 @@
 #  License: MIT (see LICENSE file)
 
 from datetime import date
-from typing import Dict, Optional, Tuple, Set
+from typing import Optional
 
 from holidays.calendars.gregorian import MON, TUE, WED, THU, FRI, SAT, SUN, _timedelta
 from holidays.holiday_base import DateArg, HolidayBase
 
 
-class ObservedRule(Dict[int, Optional[int]]):
+class ObservedRule(dict[int, Optional[int]]):
     __slots__ = ()
 
     def __add__(self, other):
@@ -141,7 +141,7 @@ class ObservedHolidayBase(HolidayBase):
         name: Optional[str] = None,
         rule: Optional[ObservedRule] = None,
         show_observed_label: bool = True,
-    ) -> Tuple[bool, Optional[date]]:
+    ) -> tuple[bool, Optional[date]]:
         dt = dt if isinstance(dt, date) else date(self._year, *dt)
 
         if not self.observed or not self._is_observed(dt):
@@ -186,7 +186,7 @@ class ObservedHolidayBase(HolidayBase):
 
     def _move_holiday(
         self, dt: date, rule: Optional[ObservedRule] = None, show_observed_label: bool = True
-    ) -> Tuple[bool, Optional[date]]:
+    ) -> tuple[bool, Optional[date]]:
         is_observed, dt_observed = self._add_observed(
             dt, rule=rule, show_observed_label=show_observed_label
         )
@@ -194,7 +194,7 @@ class ObservedHolidayBase(HolidayBase):
             self.pop(dt)
         return is_observed, dt_observed if is_observed else dt
 
-    def _populate_observed(self, dts: Set[date], multiple: bool = False) -> None:
+    def _populate_observed(self, dts: set[date], multiple: bool = False) -> None:
         """
         When multiple is True, each holiday from a given date has its own observed date.
         """

--- a/holidays/registry.py
+++ b/holidays/registry.py
@@ -11,12 +11,13 @@
 #  License: MIT (see LICENSE file)
 
 import importlib
+from collections.abc import Iterable
 from threading import RLock
-from typing import Any, Dict, Iterable, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from holidays.holiday_base import HolidayBase
 
-RegistryDict = Dict[str, Tuple[str, ...]]
+RegistryDict = dict[str, tuple[str, ...]]
 
 COUNTRIES: RegistryDict = {
     "albania": ("Albania", "AL", "ALB"),
@@ -277,7 +278,7 @@ class EntityLoader:
         return EntityLoader._get_entity_codes(FINANCIAL, (3, 4), include_aliases)
 
     @staticmethod
-    def load(prefix: str, scope: Dict) -> None:
+    def load(prefix: str, scope: dict) -> None:
         """Load country or financial entities."""
         entity_mapping = COUNTRIES if prefix == "countries" else FINANCIAL
         for module, entities in entity_mapping.items():

--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -21,8 +21,9 @@ __all__ = (
 )
 
 import warnings
+from collections.abc import Iterable
 from functools import lru_cache
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Optional, Union
 
 from holidays.holiday_base import CategoryArg, HolidayBase
 from holidays.registry import EntityLoader
@@ -282,7 +283,7 @@ def CountryHoliday(  # noqa: N802
     return country_holidays(country, subdiv, years, expand, observed, prov, state)
 
 
-def _list_localized_entities(entity_codes: Iterable[str]) -> Dict[str, List[str]]:
+def _list_localized_entities(entity_codes: Iterable[str]) -> dict[str, list[str]]:
     """
     Get all localized entities and languages they support.
 
@@ -307,7 +308,7 @@ def _list_localized_entities(entity_codes: Iterable[str]) -> Dict[str, List[str]
 
 
 @lru_cache
-def list_localized_countries(include_aliases=True) -> Dict[str, List[str]]:
+def list_localized_countries(include_aliases=True) -> dict[str, list[str]]:
     """
     Get all localized countries and languages they support.
 
@@ -324,7 +325,7 @@ def list_localized_countries(include_aliases=True) -> Dict[str, List[str]]:
 
 
 @lru_cache
-def list_localized_financial(include_aliases=True) -> Dict[str, List[str]]:
+def list_localized_financial(include_aliases=True) -> dict[str, list[str]]:
     """
     Get all localized financial markets and languages they support.
 
@@ -339,7 +340,7 @@ def list_localized_financial(include_aliases=True) -> Dict[str, List[str]]:
     return _list_localized_entities(EntityLoader.get_financial_codes(include_aliases))
 
 
-def _list_supported_entities(entity_codes: Iterable[str]) -> Dict[str, List[str]]:
+def _list_supported_entities(entity_codes: Iterable[str]) -> dict[str, list[str]]:
     """
     Get all supported entities and their subdivisions.
 
@@ -359,7 +360,7 @@ def _list_supported_entities(entity_codes: Iterable[str]) -> Dict[str, List[str]
 
 
 @lru_cache
-def list_supported_countries(include_aliases=True) -> Dict[str, List[str]]:
+def list_supported_countries(include_aliases=True) -> dict[str, list[str]]:
     """
     Get all supported countries and their subdivisions.
 
@@ -374,7 +375,7 @@ def list_supported_countries(include_aliases=True) -> Dict[str, List[str]]:
 
 
 @lru_cache
-def list_supported_financial(include_aliases=True) -> Dict[str, List[str]]:
+def list_supported_financial(include_aliases=True) -> dict[str, list[str]]:
     """
     Get all supported financial markets and their subdivisions.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "holidays"
 description = "Generate and work with holidays in Python"
 license = { file = "LICENSE" }
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 
 authors = [{ email = "dr.prodigy.github@gmail.com", name = "Maurizio Montel" }]

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,9 +2,8 @@
 
 coverage==7.6.1
 importlib-metadata==8.5.0
-numpy<2.0.0; python_version < '3.9'
-numpy==2.0.2; python_version == '3.9'
-numpy==2.1.1; python_version > '3.9'
+numpy<2.1.0; python_version < '3.10'
+numpy==2.1.2; python_version >= '3.10'
 polib==1.2.0
 pytest-cov==5.0.0
 pytest-xdist==3.6.1

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -17,7 +17,6 @@ import re
 import sys
 from datetime import date
 from pathlib import Path
-from typing import Dict, Set
 
 from git import Repo
 from github import Github
@@ -83,8 +82,8 @@ class ReleaseNotesGenerator:
         self.local_repo = Repo(Path.cwd())
         self.remote_repo = Github(self.github_token).get_repo(REPOSITORY_NAME)
 
-        self.previous_commits: Set[str] = set()
-        self.pull_requests: Dict[int, str] = {}
+        self.previous_commits: set[str] = set()
+        self.pull_requests: dict[int, str] = {}
 
         self.tag = holidays.__version__
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -14,8 +14,8 @@
 import os
 import sys
 import warnings
+from collections.abc import Generator
 from datetime import date
-from typing import Generator
 
 from dateutil.parser import parse
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ requires =
 env_list =
     docs
     pre-commit
-    python3.{13, 12, 11, 10, 9, 8}
+    python3.{13, 12, 11, 10, 9}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Drops Python 3.8 support [due to its EOL status as of October 7, 2024](https://devguide.python.org/versions/), upgrades syntax to Python 3.9 standard, and simplifies `requirements/tests.txt` for `numpy`.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [x] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
