### PR TITLE
Refactor Cambodia and Laos test cases

### DIFF
--- a/holidays/countries/cambodia.py
+++ b/holidays/countries/cambodia.py
@@ -264,10 +264,9 @@ class Cambodia(HolidayBase, InternationalHolidays, StaticHolidays, ThaiCalendarH
         # Pchum Ben Day
         pchum_ben = tr("ពិធីបុណ្យភ្ផុំបិណ្ឌ")
         pchum_ben_date = self._add_pchum_ben(pchum_ben)
-        if pchum_ben_date:
-            self._add_holiday(pchum_ben, _timedelta(pchum_ben_date, -1))
-            if self._year >= 2017:
-                self._add_holiday(pchum_ben, _timedelta(pchum_ben_date, +1))
+        self._add_holiday(pchum_ben, _timedelta(pchum_ben_date, -1))
+        if self._year >= 2017:
+            self._add_holiday(pchum_ben, _timedelta(pchum_ben_date, +1))
 
         # ព្រះរាជពិធីបុណ្យអុំទូក បណ្តែតប្រទីប និងសំពះព្រះខែអកអំបុក
         # Status: In-Use.
@@ -276,9 +275,8 @@ class Cambodia(HolidayBase, InternationalHolidays, StaticHolidays, ThaiCalendarH
         # Water Festival
         bon_om_touk = tr("ព្រះរាជពិធីបុណ្យអុំទូក បណ្តែតប្រទីប និងសំពះព្រះខែអកអំបុក")
         bon_om_touk_date = self._add_loy_krathong(bon_om_touk)
-        if bon_om_touk_date:
-            self._add_holiday(bon_om_touk, _timedelta(bon_om_touk_date, -1))
-            self._add_holiday(bon_om_touk, _timedelta(bon_om_touk_date, +1))
+        self._add_holiday(bon_om_touk, _timedelta(bon_om_touk_date, -1))
+        self._add_holiday(bon_om_touk, _timedelta(bon_om_touk_date, +1))
 
 
 class KH(Cambodia):

--- a/tests/calendars/test_thai.py
+++ b/tests/calendars/test_thai.py
@@ -14,7 +14,7 @@ import unittest
 from datetime import date
 
 from holidays import calendars
-from holidays.calendars.gregorian import FEB, MAR, MAY, JUN, JUL, AUG, SEP, OCT, NOV
+from holidays.calendars.gregorian import JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP, OCT, NOV
 from holidays.calendars.thai import KHMER_CALENDAR
 
 
@@ -176,6 +176,13 @@ class TestThaiLunisolarCalendar(unittest.TestCase):
         loy_krathong_year_date = {
             self.calendar.START_YEAR - 1: None,
             self.calendar.END_YEAR + 1: None,
+            2015: date(2015, NOV, 25),
+            2016: date(2016, NOV, 14),
+            2017: date(2017, NOV, 3),
+            2018: date(2018, NOV, 22),
+            2019: date(2019, NOV, 11),
+            2020: date(2020, OCT, 31),
+            2021: date(2021, NOV, 19),
             2022: date(2022, NOV, 8),
             2023: date(2023, NOV, 27),
             2024: date(2024, NOV, 15),
@@ -229,6 +236,11 @@ class TestThaiLunisolarCalendar(unittest.TestCase):
         meak_bochea_year_date = {
             self.calendar.START_YEAR - 1: None,
             self.calendar.END_YEAR + 1: None,
+            2015: date(2015, FEB, 3),
+            2016: date(2016, FEB, 22),
+            2017: date(2017, FEB, 11),
+            2018: date(2018, JAN, 31),
+            2019: date(2019, FEB, 19),
             2022: date(2022, FEB, 16),
             2023: date(2023, FEB, 5),
             2024: date(2024, FEB, 24),
@@ -272,6 +284,13 @@ class TestThaiLunisolarCalendar(unittest.TestCase):
         pchum_ben_year_date = {
             self.calendar.START_YEAR - 1: None,
             self.calendar.END_YEAR + 1: None,
+            2015: date(2015, OCT, 12),
+            2016: date(2016, OCT, 1),
+            2017: date(2017, SEP, 20),
+            2018: date(2018, OCT, 9),
+            2019: date(2019, SEP, 28),
+            2020: date(2020, SEP, 17),
+            2021: date(2021, OCT, 6),
             2022: date(2022, SEP, 25),
             2023: date(2023, OCT, 14),
             2024: date(2024, OCT, 2),
@@ -287,6 +306,13 @@ class TestThaiLunisolarCalendar(unittest.TestCase):
         preah_neangkoal_year_date = {
             self.calendar.START_YEAR - 1: None,
             self.calendar.END_YEAR + 1: None,
+            2015: date(2015, MAY, 6),
+            2016: date(2016, MAY, 24),
+            2017: date(2017, MAY, 14),
+            2018: date(2018, MAY, 3),
+            2019: date(2019, MAY, 22),
+            2020: date(2020, MAY, 10),
+            2021: date(2021, APR, 30),
             2022: date(2022, MAY, 19),
             2023: date(2023, MAY, 8),
             2024: date(2024, MAY, 26),
@@ -330,6 +356,13 @@ class TestThaiLunisolarCalendar(unittest.TestCase):
         visaka_bochea_year_date = {
             self.calendar.START_YEAR - 1: None,
             self.calendar.END_YEAR + 1: None,
+            2015: date(2015, MAY, 2),
+            2016: date(2016, MAY, 20),
+            2017: date(2017, MAY, 10),
+            2018: date(2018, APR, 29),
+            2019: date(2019, MAY, 18),
+            2020: date(2020, MAY, 6),
+            2021: date(2021, APR, 26),
             2022: date(2022, MAY, 15),
             2023: date(2023, MAY, 4),
             2024: date(2024, MAY, 22),

--- a/tests/countries/test_cambodia.py
+++ b/tests/countries/test_cambodia.py
@@ -19,7 +19,7 @@ from tests.common import CommonCountryTests
 class TestCambodia(CommonCountryTests, TestCase):
     @classmethod
     def setUpClass(cls):
-        super().setUpClass(Cambodia, years=list(range(1993, 2059)) + [2158])
+        super().setUpClass(Cambodia, years=range(1993, 2050))
 
     def test_country_aliases(self):
         self.assertAliases(Cambodia, KH, KHM)
@@ -136,11 +136,11 @@ class TestCambodia(CommonCountryTests, TestCase):
 
     def test_day_of_victory_over_genocidal_regime(self):
         self.assertHolidayName(
-            "ទិវាជ័យជម្នះលើរបបប្រល័យពូជសាសន៍", (f"{year}-01-07" for year in range(1993, 2058))
+            "ទិវាជ័យជម្នះលើរបបប្រល័យពូជសាសន៍", (f"{year}-01-07" for year in range(1993, 2050))
         )
 
     def test_sangkranta(self):
-        sangkranta_years_apr14 = {
+        years_sangkranta_apr14 = {
             2017,
             2018,
             2021,
@@ -153,8 +153,8 @@ class TestCambodia(CommonCountryTests, TestCase):
             2030,
             2031,
         }
-        for year in set(range(1993, 2058)).difference({2020}):
-            if year in sangkranta_years_apr14:
+        for year in set(range(1993, 2050)).difference({2020}):
+            if year in years_sangkranta_apr14:
                 self.assertHoliday(f"{year}-04-14", f"{year}-04-15", f"{year}-04-16")
             else:
                 self.assertHoliday(f"{year}-04-13", f"{year}-04-14", f"{year}-04-15")
@@ -163,7 +163,7 @@ class TestCambodia(CommonCountryTests, TestCase):
         name = "ព្រះរាជពិធីបុណ្យចម្រើនព្រះជន្ម ព្រះករុណា ព្រះបាទសម្តេចព្រះបរមនាថ នរោត្តម សីហមុនី"
         self.assertNoHolidayName(name, 2004)
         self.assertHolidayName(name, (f"{year}-05-13" for year in range(2005, 2020)))
-        self.assertHolidayName(name, (f"{year}-05-14" for year in range(2005, 2058)))
+        self.assertHolidayName(name, (f"{year}-05-14" for year in range(2005, 2050)))
         self.assertHolidayName(name, (f"{year}-05-15" for year in range(2005, 2020)))
 
     def test_national_day_of_remembrance(self):
@@ -180,11 +180,11 @@ class TestCambodia(CommonCountryTests, TestCase):
     def test_queen_mother_monineath_birthday(self):
         name = "ព្រះរាជពិធីបុណ្យចម្រើនព្រះជន្ម សម្តេចព្រះមហាក្សត្រី ព្រះវររាជមាតា នរោត្តម មុនិនាថ សីហនុ"
         self.assertNoHolidayName(name, 1993)
-        self.assertHolidayName(name, (f"{year}-06-18" for year in range(1994, 2058)))
+        self.assertHolidayName(name, (f"{year}-06-18" for year in range(1994, 2050)))
 
     def test_constitution_day(self):
         self.assertHolidayName(
-            "ទិវាប្រកាសរដ្ឋធម្មនុញ្ញ", (f"{year}-09-24" for year in range(1993, 2058))
+            "ទិវាប្រកាសរដ្ឋធម្មនុញ្ញ", (f"{year}-09-24" for year in range(1993, 2050))
         )
 
     def test_king_sihanouk_memorial_day(self):
@@ -194,7 +194,7 @@ class TestCambodia(CommonCountryTests, TestCase):
             " និងឯកភាពជាតិខ្មែរ ព្រះបរមរតនកោដ្ឋ"
         )
         self.assertNoHolidayName(name, 2011)
-        self.assertHolidayName(name, (f"{year}-10-15" for year in range(2012, 2058)))
+        self.assertHolidayName(name, (f"{year}-10-15" for year in range(2012, 2050)))
 
     def test_paris_peace_agreement_day(self):
         name = "ទិវារំលឹកសន្ធិសញ្ញាសន្តិភាពទីក្រុងប៉ារីស"
@@ -208,59 +208,15 @@ class TestCambodia(CommonCountryTests, TestCase):
             "ព្រះមហាក្សត្រនៃព្រះរាជាណាចក្រកម្ពុជា"
         )
         self.assertNoHolidayName(name, 2003)
-        self.assertHolidayName(name, (f"{year}-10-29" for year in range(2004, 2058)))
+        self.assertHolidayName(name, (f"{year}-10-29" for year in range(2004, 2050)))
 
     def test_national_independence_day(self):
-        self.assertHolidayName("ពិធីបុណ្យឯករាជ្យជាតិ", (f"{year}-11-09" for year in range(1993, 2058)))
+        self.assertHolidayName("ពិធីបុណ្យឯករាជ្យជាតិ", (f"{year}-11-09" for year in range(1993, 2050)))
 
     def test_international_human_rights_day(self):
         name = "ទិវាសិទ្ធិមនុស្សអន្តរជាតិ"
         self.assertHolidayName(name, (f"{year}-12-10" for year in range(1993, 2020)))
         self.assertNoHolidayName(name, 2020)
-
-    def test_meak_bochea(self):
-        name = "ពិធីបុណ្យមាឃបូជា"
-        self.assertHolidayName(
-            name,
-            "2015-02-03",
-            "2016-02-22",
-            "2017-02-11",
-            "2018-01-31",
-            "2019-02-19",
-        )
-        self.assertNoHolidayName(name, 2158)
-
-    def test_visaka_bochea(self):
-        name = "ពិធីបុណ្យវិសាខបូជា"
-        self.assertHolidayName(
-            name,
-            "2015-05-02",
-            "2016-05-20",
-            "2017-05-10",
-            "2018-04-29",
-            "2019-05-18",
-            "2020-05-06",
-            "2021-04-26",
-            "2022-05-15",
-            "2023-05-04",
-        )
-        self.assertNoHolidayName(name, 2158)
-
-    def test_preah_neangkoal(self):
-        name = "ព្រះរាជពិធីច្រត់ព្រះនង្គ័ល"
-        self.assertHolidayName(
-            name,
-            "2015-05-06",
-            "2016-05-24",
-            "2017-05-14",
-            "2018-05-03",
-            "2019-05-22",
-            "2020-05-10",
-            "2021-04-30",
-            "2022-05-19",
-            "2023-05-08",
-        )
-        self.assertNoHolidayName(name, 2158)
 
     def test_pchum_ben(self):
         name = "ពិធីបុណ្យភ្ផុំបិណ្ឌ"
@@ -294,7 +250,6 @@ class TestCambodia(CommonCountryTests, TestCase):
             "2023-10-14",
             "2023-10-15",
         )
-        self.assertNoHolidayName(name, 2158)
 
     def test_bon_om_touk(self):
         name = "ព្រះរាជពិធីបុណ្យអុំទូក បណ្តែតប្រទីប និងសំពះព្រះខែអកអំបុក"

--- a/tests/countries/test_laos.py
+++ b/tests/countries/test_laos.py
@@ -20,7 +20,7 @@ from tests.common import CommonCountryTests
 class TestLaos(CommonCountryTests, TestCase):
     @classmethod
     def setUpClass(cls):
-        super().setUpClass(Laos, years=range(1976, 2058), years_non_observed=range(2018, 2058))
+        super().setUpClass(Laos, years=range(1976, 2050), years_non_observed=range(2018, 2050))
 
     def test_country_aliases(self):
         self.assertAliases(Laos, LA, LAO)
@@ -92,7 +92,7 @@ class TestLaos(CommonCountryTests, TestCase):
         )
 
     def test_new_years_day(self):
-        self.assertHoliday(f"{year}-01-01" for year in range(1976, 2058))
+        self.assertHoliday(f"{year}-01-01" for year in range(1976, 2050))
 
         self.assertNoNonObservedHoliday(
             "2012-01-02",
@@ -102,7 +102,7 @@ class TestLaos(CommonCountryTests, TestCase):
         )
 
     def test_international_women_rights_day(self):
-        self.assertHoliday(f"{year}-03-08" for year in range(1976, 2058))
+        self.assertHoliday(f"{year}-03-08" for year in range(1976, 2050))
 
         self.assertNoNonObservedHoliday(
             "2015-03-09",
@@ -112,7 +112,7 @@ class TestLaos(CommonCountryTests, TestCase):
     def test_laos_new_year_day(self):
         songkran_years_apr_13_15 = {2012, 2017}
         songkran_years_apr_13_16 = {2016, 2020, 2024}
-        for year in range(1976, 2058):
+        for year in range(1976, 2050):
             if year in songkran_years_apr_13_15:
                 self.assertHoliday(f"{year}-04-13", f"{year}-04-14", f"{year}-04-15")
             elif year in songkran_years_apr_13_16:
@@ -142,7 +142,7 @@ class TestLaos(CommonCountryTests, TestCase):
         )
 
     def test_labor_day(self):
-        self.assertHoliday(f"{year}-05-01" for year in range(1976, 2058))
+        self.assertHoliday(f"{year}-05-01" for year in range(1976, 2050))
 
         self.assertNoNonObservedHoliday(
             "2016-05-02",
@@ -154,7 +154,7 @@ class TestLaos(CommonCountryTests, TestCase):
         self.assertHoliday(f"{year}-06-01" for year in range(1990, 2018))
 
     def test_lao_national_day(self):
-        self.assertHoliday(f"{year}-12-02" for year in range(1976, 2058))
+        self.assertHoliday(f"{year}-12-02" for year in range(1976, 2050))
 
         self.assertNoNonObservedHoliday(
             "2012-12-03",


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

As proposed by @KJhellico in #2081 :
> Now that 2058 is no longer a special year for Thai calendar, can we replace it with a more standard 2050? Or rather, 2049, because most countries use range(N, 2050).

> I think the checks for 2158 are more related to Thai calendar tests than to Thailand itself. And since `tests\calendars\test_thai.py` already contains checks for this year, they are redundant here.

This PR aims to address these issues.
- Switching test case end date back to 2050 like other typical country-level implementations.
- Moving all relevant Thai calendar-related testing to Thai calendar test cases, except for `Pchum Ben` and `Bon Om Tok` since we'll still need to check for its 2-day and 3-day celebration variants.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
