### PR TITLE
Fix `make l10n` removing loc comment for Asarnha Bucha

### DIFF
--- a/holidays/countries/thailand.py
+++ b/holidays/countries/thailand.py
@@ -448,9 +448,10 @@ class Thailand(ObservedHolidayBase, InternationalHolidays, StaticHolidays, ThaiC
         #  - CASE 2: SAT-SUN -> 1 in-lieu on MON
         #  - CASE 3: SUN-MON -> 1 in-lieu on TUE
 
-        # Asarnha Bucha.
         self._add_observed(
-            self._add_asarnha_bucha(tr("วันอาสาฬหบูชา")), rule=SAT_SUN_TO_NEXT_MON_TUE
+            # Asarnha Bucha.
+            self._add_asarnha_bucha(tr("วันอาสาฬหบูชา")),
+            rule=SAT_SUN_TO_NEXT_MON_TUE,
         )
 
         # วันเข้าพรรษา


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Further fix for #2081 so `make l10n` command no longer removes the translation comment from Asarnha Bucha localization entry.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
