### PR TITLE
Update Germany holidays: add East German Uprising Day 2028 in Berlin

### DIFF
--- a/holidays/countries/germany.py
+++ b/holidays/countries/germany.py
@@ -12,7 +12,7 @@
 
 from gettext import gettext as tr
 
-from holidays.calendars.gregorian import MAY, OCT
+from holidays.calendars.gregorian import MAY, JUN, OCT
 from holidays.constants import CATHOLIC, PUBLIC
 from holidays.groups import ChristianHolidays, InternationalHolidays, StaticHolidays
 from holidays.holiday_base import HolidayBase
@@ -304,6 +304,13 @@ class DEU(Germany):
 
 
 class GermanyStaticHolidays:
+    """
+    References:
+     - https://www.stuttgarter-zeitung.de/inhalt.reformationstag-2017-einmalig-bundesweiter-feiertag.b7e189b3-a33d-41a3-a0f4-141cd13df54e.html
+     - https://www.bbc.com/news/world-europe-52574748
+     - https://gesetze.berlin.de/bsbe/document/jlr-FeiertGBEV8P1
+    """
+
     special_public_holidays = {
         2017: (OCT, 31, tr("Reformationstag")),
     }
@@ -329,4 +336,6 @@ class GermanyStaticHolidays:
                 "und der Beendigung des Zweiten Weltkriegs in Europa"
             ),
         ),
+        # 75th anniversary of the East German uprising of 1953.
+        2028: (JUN, 17, tr("75. Jahrestag des Aufstandes vom 17. Juni 1953")),
     }

--- a/holidays/locale/de/LC_MESSAGES/DE.po
+++ b/holidays/locale/de/LC_MESSAGES/DE.po
@@ -13,9 +13,9 @@
 # Germany holidays.
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.59\n"
+"Project-Id-Version: Holidays 0.60\n"
 "POT-Creation-Date: 2023-04-04 16:13+0300\n"
-"PO-Revision-Date: 2024-10-17 11:43+0700\n"
+"PO-Revision-Date: 2024-10-30 02:14+0700\n"
 "Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
 "Language-Team: Holidays localization team\n"
 "Language: de\n"
@@ -114,4 +114,8 @@ msgstr ""
 
 #. World Children's Day.
 msgid "Weltkindertag"
+msgstr ""
+
+#. 75th anniversary of the East German uprising of 1953.
+msgid "75. Jahrestag des Aufstandes vom 17. Juni 1953"
 msgstr ""

--- a/holidays/locale/en_US/LC_MESSAGES/DE.po
+++ b/holidays/locale/en_US/LC_MESSAGES/DE.po
@@ -14,9 +14,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.59\n"
+"Project-Id-Version: Holidays 0.60\n"
 "POT-Creation-Date: 2023-04-04 16:13+0300\n"
-"PO-Revision-Date: 2024-10-17 11:43+0700\n"
+"PO-Revision-Date: 2024-10-30 02:14+0700\n"
 "Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
 "Language-Team: Holidays localization team\n"
 "Language: en_US\n"
@@ -120,3 +120,7 @@ msgstr "Assumption Day"
 #. World Children's Day.
 msgid "Weltkindertag"
 msgstr "World Children's Day"
+
+#. 75th anniversary of the East German uprising of 1953.
+msgid "75. Jahrestag des Aufstandes vom 17. Juni 1953"
+msgstr "75th anniversary of the East German uprising of 1953"

--- a/holidays/locale/th/LC_MESSAGES/DE.po
+++ b/holidays/locale/th/LC_MESSAGES/DE.po
@@ -14,11 +14,11 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.59\n"
+"Project-Id-Version: Holidays 0.60\n"
 "POT-Creation-Date: 2024-09-05 23:21+0700\n"
-"PO-Revision-Date: 2024-10-17 11:44+0700\n"
+"PO-Revision-Date: 2024-10-30 02:14+0700\n"
 "Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
-"Language-Team: Holidays Localization Team\n"
+"Language-Team: Holidays localization team\n"
 "Language: th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -120,3 +120,7 @@ msgstr "วันสมโภชแม่พระรับเกียรติ
 #. World Children's Day.
 msgid "Weltkindertag"
 msgstr "วันเด็กสากล"
+
+#. 75th anniversary of the East German uprising of 1953.
+msgid "75. Jahrestag des Aufstandes vom 17. Juni 1953"
+msgstr "วันครบรอบ 75 ปีของการก่อการกำเริบในเยอรมนีตะวันออก ค.ศ. 1953"

--- a/holidays/locale/uk/LC_MESSAGES/DE.po
+++ b/holidays/locale/uk/LC_MESSAGES/DE.po
@@ -14,9 +14,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.59\n"
+"Project-Id-Version: Holidays 0.60\n"
 "POT-Creation-Date: 2023-04-04 16:13+0300\n"
-"PO-Revision-Date: 2024-10-17 11:44+0700\n"
+"PO-Revision-Date: 2024-10-30 02:15+0700\n"
 "Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
 "Language-Team: Holidays localization team\n"
 "Language: uk\n"
@@ -120,3 +120,7 @@ msgstr "Внебовзяття Пресвятої Діви Марії"
 #. World Children's Day.
 msgid "Weltkindertag"
 msgstr "Всесвітній день дітей"
+
+#. 75th anniversary of the East German uprising of 1953.
+msgid "75. Jahrestag des Aufstandes vom 17. Juni 1953"
+msgstr "75-та річниця Повста́ння 1953 у Схі́дній Німе́ччині"

--- a/holidays/locale/uk/LC_MESSAGES/DE.po
+++ b/holidays/locale/uk/LC_MESSAGES/DE.po
@@ -123,4 +123,4 @@ msgstr "Всесвітній день дітей"
 
 #. 75th anniversary of the East German uprising of 1953.
 msgid "75. Jahrestag des Aufstandes vom 17. Juni 1953"
-msgstr "75-та річниця Повста́ння 1953 у Схі́дній Німе́ччині"
+msgstr "75-та річниця Повстання 1953 у Східній Німеччині"

--- a/snapshots/countries/DE_BE.json
+++ b/snapshots/countries/DE_BE.json
@@ -358,6 +358,7 @@
     "2028-05-01": "Labor Day",
     "2028-05-25": "Ascension Day",
     "2028-06-05": "Whit Monday",
+    "2028-06-17": "75th anniversary of the East German uprising of 1953",
     "2028-10-03": "German Unity Day",
     "2028-12-25": "Christmas Day",
     "2028-12-26": "Second Day of Christmas",

--- a/tests/countries/test_germany.py
+++ b/tests/countries/test_germany.py
@@ -206,6 +206,15 @@ class TestDE(CommonCountryTests, TestCase):
         for subdiv in subdivs_that_dont:
             self.assertNoHoliday(self.subdiv_holidays[subdiv], "2025-05-08")
 
+    def test_75_jahrestag_des_aufstandes_vom_17_juni_1953(self):
+        subdivs_that_have = {"BE"}
+        subdivs_that_dont = set(DE.subdivisions) - subdivs_that_have
+
+        for subdiv in subdivs_that_have:
+            self.assertHoliday(self.subdiv_holidays[subdiv], "2028-06-17")
+        for subdiv in subdivs_that_dont:
+            self.assertNoHoliday(self.subdiv_holidays[subdiv], "2028-06-17")
+
     def test_christi_himmelfahrt(self):
         known_good = (
             "2014-05-29",


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Adds the `75th anniversary of the East German uprising of 1953` for Berlin, Germany in 2028. English localization is partially based on a [DW article](https://www.dw.com/en/berlin-commemorates-1953-uprising-in-east-germany/a-39289423) and Ukranian one could use a review here @KJhellico .

Resolves #2089 .

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
