### PR TITLE
Update CH holidays: rename Neujahrestag to Neujahrstag

### DIFF
--- a/holidays/countries/switzerland.py
+++ b/holidays/countries/switzerland.py
@@ -66,7 +66,7 @@ class Switzerland(ObservedHolidayBase, ChristianHolidays, InternationalHolidays)
 
     def _populate_public_holidays(self):
         # New Year's Day.
-        self._add_new_years_day(tr("Neujahr"))
+        self._add_new_years_day(tr("Neujahrstag"))
 
         # Ascension Day.
         self._add_ascension_thursday(tr("Auffahrt"))

--- a/holidays/countries/switzerland.py
+++ b/holidays/countries/switzerland.py
@@ -66,7 +66,7 @@ class Switzerland(ObservedHolidayBase, ChristianHolidays, InternationalHolidays)
 
     def _populate_public_holidays(self):
         # New Year's Day.
-        self._add_new_years_day(tr("Neujahrestag"))
+        self._add_new_years_day(tr("Neujahr"))
 
         # Ascension Day.
         self._add_ascension_thursday(tr("Auffahrt"))

--- a/holidays/locale/de/LC_MESSAGES/CH.po
+++ b/holidays/locale/de/LC_MESSAGES/CH.po
@@ -27,7 +27,7 @@ msgstr ""
 "X-Generator: Poedit 3.4\n"
 
 #. New Year's Day.
-msgid "Neujahrestag"
+msgid "Neujahrstag"
 msgstr ""
 
 #. Ascension Day.

--- a/holidays/locale/en_US/LC_MESSAGES/CH.po
+++ b/holidays/locale/en_US/LC_MESSAGES/CH.po
@@ -28,7 +28,7 @@ msgstr ""
 "X-Generator: Poedit 3.4\n"
 
 #. New Year's Day.
-msgid "Neujahrestag"
+msgid "Neujahrstag"
 msgstr "New Year's Day"
 
 #. Ascension Day.

--- a/holidays/locale/fr/LC_MESSAGES/CH.po
+++ b/holidays/locale/fr/LC_MESSAGES/CH.po
@@ -27,7 +27,7 @@ msgstr ""
 "X-Generator: Poedit 3.4\n"
 
 #. New Year's Day.
-msgid "Neujahrestag"
+msgid "Neujahrstag"
 msgstr "Nouvel An"
 
 #. Ascension Day.

--- a/holidays/locale/it/LC_MESSAGES/CH.po
+++ b/holidays/locale/it/LC_MESSAGES/CH.po
@@ -27,7 +27,7 @@ msgstr ""
 "X-Generator: Poedit 3.4\n"
 
 #. New Year's Day.
-msgid "Neujahrestag"
+msgid "Neujahrstag"
 msgstr "Capodanno"
 
 #. Ascension Day.

--- a/holidays/locale/uk/LC_MESSAGES/CH.po
+++ b/holidays/locale/uk/LC_MESSAGES/CH.po
@@ -27,7 +27,7 @@ msgstr ""
 "X-Generator: Poedit 3.4\n"
 
 #. New Year's Day.
-msgid "Neujahrestag"
+msgid "Neujahrstag"
 msgstr "Новий рік"
 
 #. Ascension Day.

--- a/tests/countries/test_switzerland.py
+++ b/tests/countries/test_switzerland.py
@@ -37,7 +37,7 @@ class TestSwitzerland(CommonCountryTests, TestCase):
                 CH(categories=(HALF_DAY, OPTIONAL, PUBLIC), years=2018, subdiv=p).values()
             )
         all_h = {  # Holidays names in their chronological order.
-            "Neujahrestag",
+            "Neujahrstag",
             "Berchtoldstag",
             "Heilige Drei Könige",
             "Jahrestag der Ausrufung der Republik",
@@ -71,7 +71,7 @@ class TestSwitzerland(CommonCountryTests, TestCase):
 
     def test_fixed_holidays(self):
         # New Year's Day.
-        self.assertHolidayName("Neujahrestag", (f"{year}-01-01" for year in range(1970, 2050)))
+        self.assertHolidayName("Neujahrstag", (f"{year}-01-01" for year in range(1970, 2050)))
         # National Day.
         self.assertHolidayName("Nationalfeiertag", (f"{year}-08-01" for year in range(1970, 2050)))
         # Christmas Day.
@@ -667,7 +667,7 @@ class TestSwitzerland(CommonCountryTests, TestCase):
 
     def test_l10n_default(self):
         self.assertLocalizedHolidays(
-            ("2023-01-01", "Neujahrestag"),
+            ("2023-01-01", "Neujahrstag"),
             ("2023-01-02", "Berchtoldstag"),
             ("2023-01-06", "Heilige Drei Könige"),
             ("2023-03-01", "Jahrestag der Ausrufung der Republik"),


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Like in other German speaking countries, January 01 is called "Neujahr" in Switzerland, not "Neujahrestag". "Neujahr*e*stag" would be wrong anyway, it would be "Neujahrstag".

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [ ] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
