### PR TITLE
Update Finland holidays: fix Independence Day appearing pre-1917

### DIFF
--- a/holidays/countries/finland.py
+++ b/holidays/countries/finland.py
@@ -28,6 +28,7 @@ class Finland(HolidayBase, ChristianHolidays, InternationalHolidays):
         - https://en.wikipedia.org/wiki/Flag_flying_days_in_Finland#Customary_flag_days
         - https://intermin.fi/en/flag-and-arms/flag-flying-days
         - https://intermin.fi/en/flag-and-arms/flag-days/2024
+        - https://en.wikipedia.org/wiki/Independence_Day_(Finland)
     """
 
     country = "FI"
@@ -90,8 +91,9 @@ class Finland(HolidayBase, ChristianHolidays, InternationalHolidays):
         else:
             self._add_holiday_nov_1(name)
 
-        # Independence Day.
-        self._add_holiday_dec_6(tr("Itsenäisyyspäivä"))
+        if self._year >= 1917:
+            # Independence Day.
+            self._add_holiday_dec_6(tr("Itsenäisyyspäivä"))
 
         # Christmas Eve.
         self._add_christmas_eve(tr("Jouluaatto"))

--- a/tests/countries/test_finland.py
+++ b/tests/countries/test_finland.py
@@ -170,7 +170,8 @@ class TestFinland(CommonCountryTests, TestCase):
     def test_independence_day(self):
         name = "Itsenäisyyspäivä"
         self.assertHolidayName(name, (f"{year}-12-06" for year in range(1917, 2050)))
-        self.assertNoHolidayName(name, (f"{year}-12-06" for year in range(1853, 1917)))
+        self.assertNoHoliday(f"{year}-12-06" for year in range(1853, 1917))
+        self.assertNoHolidayName(name, range(1853, 1917))
 
     def _test_unofficial_holiday(self, name, since):
         start_year, month, day = (int(part) for part in since.split("-"))

--- a/tests/countries/test_finland.py
+++ b/tests/countries/test_finland.py
@@ -27,7 +27,7 @@ class TestFinland(CommonCountryTests, TestCase):
         self.assertAliases(Finland, FI, FIN)
 
     def test_fixed_holidays(self):
-        for year in range(2010, 2030):
+        for year in range(2010, 2031):
             self.assertHoliday(
                 f"{year}-01-01",
                 f"{year}-01-06",
@@ -166,6 +166,11 @@ class TestFinland(CommonCountryTests, TestCase):
             "1956-11-01",
             "1957-11-01",
         )
+
+    def test_independence_day(self):
+        name = "Itsenäisyyspäivä"
+        self.assertHolidayName(name, (f"{year}-12-06" for year in range(1917, 2031)))
+        self.assertNoHolidayName(name, 1916)
 
     def _test_unofficial_holiday(self, name, since):
         start_year, month, day = (int(part) for part in since.split("-"))

--- a/tests/countries/test_finland.py
+++ b/tests/countries/test_finland.py
@@ -21,13 +21,13 @@ class TestFinland(CommonCountryTests, TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass(Finland)
-        cls.unofficial_holidays = Finland(categories=UNOFFICIAL, years=range(1853, 2031))
+        cls.unofficial_holidays = Finland(categories=UNOFFICIAL, years=range(1853, 2050))
 
     def test_country_aliases(self):
         self.assertAliases(Finland, FI, FIN)
 
     def test_fixed_holidays(self):
-        for year in range(2010, 2031):
+        for year in range(2010, 2050):
             self.assertHoliday(
                 f"{year}-01-01",
                 f"{year}-01-06",
@@ -169,15 +169,15 @@ class TestFinland(CommonCountryTests, TestCase):
 
     def test_independence_day(self):
         name = "Itsenäisyyspäivä"
-        self.assertHolidayName(name, (f"{year}-12-06" for year in range(1917, 2031)))
-        self.assertNoHolidayName(name, 1916)
+        self.assertHolidayName(name, (f"{year}-12-06" for year in range(1917, 2050)))
+        self.assertNoHolidayName(name, (f"{year}-12-06" for year in range(1853, 1917)))
 
     def _test_unofficial_holiday(self, name, since):
         start_year, month, day = (int(part) for part in since.split("-"))
         self.assertHolidayName(
             name,
             self.unofficial_holidays,
-            (f"{year}-{month}-{day}" for year in range(start_year, 2031)),
+            (f"{year}-{month}-{day}" for year in range(start_year, 2050)),
         )
         self.assertNoHolidayName(name, self.unofficial_holidays, start_year - 1)
 


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Fixing Finland's Independence Day appearing pre-1917, also standardized the test cases end date to 2049 as other entries.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
