### PR TITLE
Add French subdivision aliases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -437,7 +437,7 @@ All other default values are highlighted with bold:
      - UNOFFICIAL
    * - France
      - FR
-     - DOM/TOM: BL, GES, GP, GY, MF, MQ, NC, PF, RE, WF, YT
+     - DOM/TOM: BL (Saint-Barthélemy), GES (Alsace, Champagne-Ardenne, Lorraine), GP (Guadeloupe), GY (Guyane), MF (Saint-Martin), MQ (Martinique), NC (Nouvelle-Calédonie), PF (Polynésie Française), RE (La Réunion), WF (Wallis-et-Futuna), YT (Mayotte)
      - en_US, **fr**, uk
      -
    * - Gabon

--- a/holidays/countries/france.py
+++ b/holidays/countries/france.py
@@ -35,18 +35,33 @@ class France(HolidayBase, ChristianHolidays, InternationalHolidays):
     default_language = "fr"
     supported_languages = ("en_US", "fr", "uk")
     subdivisions = (
-        "BL",  # Saint Barthelemy.
+        "BL",  # Saint-Barthélemy.
         "GES",  # Alsace, Champagne-Ardenne, Lorraine(Moselle).
         "GP",  # Guadeloupe.
         "GY",  # Guyane.
-        "MF",  # Saint Martin.
+        "MF",  # Saint-Martin.
         "MQ",  # Martinique.
         "NC",  # Nouvelle-Calédonie,
         "PF",  # Polynésie Française.
-        "RE",  # Reunion.
+        "RE",  # La Réunion.
         "WF",  # Wallis-et-Futuna.
         "YT",  # Mayotte.
     )
+    subdivisions_aliases = {
+        "Saint-Barthélemy": "BL",
+        "Alsace": "GES",
+        "Champagne-Ardenne": "GES",
+        "Lorraine": "GES",
+        "Guadeloupe": "GP",
+        "Guyane": "GY",
+        "Saint-Martin": "MF",
+        "Martinique": "MQ",
+        "Nouvelle-Calédonie": "NC",
+        "Polynésie Française": "PF",
+        "La Réunion": "RE",
+        "Wallis-et-Futuna": "WF",
+        "Mayotte": "YT",
+    }
 
     _deprecated_subdivisions = (
         "Alsace-Moselle",


### PR DESCRIPTION
## Proposed change

I had to look up in the source code what MQ, RE... meant. The README didn't help either, just listing the raw codes available.

Those are not of common use in the French culture, contrary to say, AZ meaning Arizona in the US culture.

Also fixed the official spelling.

## Type of change

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [X] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

- [X] I've followed the [contributing guidelines][contributing-guidelines]
- [X] I've successfully run `make check`, all checks and tests are green

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source

## Additional notes

For the record, it started with me adding a holiday calendar in my Home Assistant. I was left puzzled with that list:

![Screenshot 2024-12-11 at 10-45-56 Paramètres – Home Assistant](https://github.com/user-attachments/assets/33c23f39-ccc4-4f05-802a-ab851013b6f4)

And when I couldn't find the meaning of those abbreviations in the documentation either, I thought it was time to contribute.

The next step is to get in touch with the maintainers of this Home Assistant integration, and ask them to use the list of subdivision aliases when available.