### PR TITLE
Add South Korea's temporary public holidays

### DIFF
--- a/holidays/countries/south_korea.py
+++ b/holidays/countries/south_korea.py
@@ -108,7 +108,8 @@ class SouthKorea(
             if not self._is_observed(dt):
                 continue
             dt_observed = self._get_observed_date(
-                dt, SUN_TO_NEXT_WORKDAY if dt in three_day_holidays else SAT_SUN_TO_NEXT_WORKDAY
+                dt,
+                (SUN_TO_NEXT_WORKDAY if dt in three_day_holidays else SAT_SUN_TO_NEXT_WORKDAY),
             )
             if dt_observed != dt or len(self.get_list(dt)) > 1:
                 if dt_observed == dt:
@@ -333,7 +334,7 @@ class SouthKoreaLunisolarHolidays(_CustomChineseHolidays):
 class SouthKoreaStaticHolidays:
     """
     References:
-        - https://namu.wiki/w/임시공휴일 *
+        - https://namu.wiki/w/임ㅜ시공휴일 *
         - https://namu.wiki/w/공휴일/대한민국 **
         - https://namu.wiki/w/대체%20휴일%20제도
 
@@ -615,8 +616,12 @@ class SouthKoreaStaticHolidays:
         2020: (AUG, 17, temporary_public_holiday),
         # Added to create a 6-day long holiday period.
         2023: (OCT, 2, temporary_public_holiday),
-        # 76th Anniversary of the Armed Forces of Korea.
-        2024: (OCT, 1, armed_forces_day),
+        2024: (
+            # 76th Anniversary of the Armed Forces of Korea.
+            (OCT, 1, armed_forces_day),
+            # Added to create a 6-day long holiday period.
+            (JAN, 27, temporary_public_holiday),
+        ),
     }
     # Pre-2014 Alternate Holidays
     # https://namu.wiki/w/대체%20휴일%20제도#s-4.2.1


### PR DESCRIPTION
Add South Korea's temporary public holidays to January 27th, 2024.

<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Your PR description goes here.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [x] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
