### PR TITLE
Update South Korea holidays: 2025 temporary public holidays

### DIFF
--- a/holidays/countries/south_korea.py
+++ b/holidays/countries/south_korea.py
@@ -334,7 +334,7 @@ class SouthKoreaLunisolarHolidays(_CustomChineseHolidays):
 class SouthKoreaStaticHolidays:
     """
     References:
-        - https://namu.wiki/w/임ㅜ시공휴일 *
+        - https://namu.wiki/w/임시공휴일 *
         - https://namu.wiki/w/공휴일/대한민국 **
         - https://namu.wiki/w/대체%20휴일%20제도
 

--- a/holidays/countries/south_korea.py
+++ b/holidays/countries/south_korea.py
@@ -108,7 +108,8 @@ class SouthKorea(
             if not self._is_observed(dt):
                 continue
             dt_observed = self._get_observed_date(
-                dt, SUN_TO_NEXT_WORKDAY if dt in three_day_holidays else SAT_SUN_TO_NEXT_WORKDAY
+                dt,
+                (SUN_TO_NEXT_WORKDAY if dt in three_day_holidays else SAT_SUN_TO_NEXT_WORKDAY),
             )
             if dt_observed != dt or len(self.get_list(dt)) > 1:
                 if dt_observed == dt:
@@ -333,7 +334,7 @@ class SouthKoreaLunisolarHolidays(_CustomChineseHolidays):
 class SouthKoreaStaticHolidays:
     """
     References:
-        - https://namu.wiki/w/임시공휴일 *
+        - https://namu.wiki/w/임ㅜ시공휴일 *
         - https://namu.wiki/w/공휴일/대한민국 **
         - https://namu.wiki/w/대체%20휴일%20제도
 
@@ -617,6 +618,8 @@ class SouthKoreaStaticHolidays:
         2023: (OCT, 2, temporary_public_holiday),
         # 76th Anniversary of the Armed Forces of Korea.
         2024: (OCT, 1, armed_forces_day),
+        # Added to create a 6-day long holiday period.
+        2025: (JAN, 27, temporary_public_holiday),
     }
     # Pre-2014 Alternate Holidays
     # https://namu.wiki/w/대체%20휴일%20제도#s-4.2.1

--- a/holidays/countries/south_korea.py
+++ b/holidays/countries/south_korea.py
@@ -108,8 +108,7 @@ class SouthKorea(
             if not self._is_observed(dt):
                 continue
             dt_observed = self._get_observed_date(
-                dt,
-                (SUN_TO_NEXT_WORKDAY if dt in three_day_holidays else SAT_SUN_TO_NEXT_WORKDAY),
+                dt, SUN_TO_NEXT_WORKDAY if dt in three_day_holidays else SAT_SUN_TO_NEXT_WORKDAY
             )
             if dt_observed != dt or len(self.get_list(dt)) > 1:
                 if dt_observed == dt:

--- a/snapshots/countries/KR_COMMON.json
+++ b/snapshots/countries/KR_COMMON.json
@@ -1293,6 +1293,7 @@
     "2024-10-09": "Hangul Day",
     "2024-12-25": "Christmas Day",
     "2025-01-01": "New Year's Day",
+    "2025-01-27": "Temporary Public Holiday",
     "2025-01-28": "The day preceding Korean New Year",
     "2025-01-29": "Korean New Year",
     "2025-01-30": "The second day of Korean New Year",

--- a/tests/countries/test_south_korea.py
+++ b/tests/countries/test_south_korea.py
@@ -78,6 +78,7 @@ class TestSouthKorea(CommonCountryTests, TestCase):
             "2020-08-17",
             "2023-10-02",
             "2024-10-01",
+            "2025-01-27",
         )
         # Pre-2014 Observance sans "1960-12-26"
         self.assertNoNonObservedHoliday(


### PR DESCRIPTION
Add South Korea's temporary public holidays to [January 27th, 2025.](https://biz.chosun.com/en/en-policy/2025/01/07/IJUARF6LM5DBJPGYGGXRYGM7X4/)

<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Your PR description goes here.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
