### PR TITLE
Add faster date parsing from strings in ISO 8601 format

### DIFF
--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -593,6 +593,7 @@ class HolidayBase(dict[date, str]):
 
         # Key is `str` instance.
         elif isinstance(key, str):
+            # key possibly contains a date in YYYY-MM-DD or YYYYMMDD format.
             if len(key) in {8, 10}:
                 try:
                     dt = date.fromisoformat(key)

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -584,6 +584,7 @@ class HolidayBase(dict[date, str]):
 
         to :class:`datetime.date`, which is how it's stored by the class."""
 
+        dt: Optional[date] = None
         # Try to catch `date` and `str` type keys first.
         # Using type() here to skip date subclasses.
         # Key is `date`.
@@ -592,10 +593,16 @@ class HolidayBase(dict[date, str]):
 
         # Key is `str` instance.
         elif isinstance(key, str):
-            try:
-                dt = parse(key).date()
-            except (OverflowError, ValueError):
-                raise ValueError(f"Cannot parse date from string '{key}'")
+            if len(key) in {8, 10}:
+                try:
+                    dt = date.fromisoformat(key)
+                except ValueError:
+                    pass
+            if dt is None:
+                try:
+                    dt = parse(key).date()
+                except (OverflowError, ValueError):
+                    raise ValueError(f"Cannot parse date from string '{key}'")
 
         # Key is `datetime` instance.
         elif isinstance(key, datetime):


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Add faster date parsing from strings in ISO 8601 format ("YYYY-MM-DD" or "YYYYMMDD"): use `date.fromisoformat()` instead of `dateutil.parser.parse()`.
Speed comparison:

```shell
python -m timeit -s "from dateutil.parser import parse" -n 100000 "d = parse('2024-12-25')"
100000 loops, best of 5: 20.7 usec per loop

python -m timeit -s "from datetime import date" -n 10000 "d = date.fromisoformat('2024-12-25')"
10000 loops, best of 5: 127 nsec per loop
```

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
