### PR TITLE
Add iCalendar export support

### DIFF
--- a/holidays/ical.py
+++ b/holidays/ical.py
@@ -1,0 +1,60 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see AUTHORS file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/holidays
+#  License: MIT (see LICENSE file)
+
+class ICalExporter:
+    def __init__(self, holidays_object, language="en", return_bytes=False):
+        """Initialize iCalendar exporter
+
+        Args:
+        - holidays_object: Holidays object containing holiday data
+        - language (str) Output language code (default: 'en')
+        - return_bytes(bool): If True, return bytes instead of string
+        """
+        self.holidays = holidays_object
+        self.language = language
+        self.return_bytes = return_bytes
+
+    def generate_event(self, date, holiday_name):
+        """Generate a single holiday event
+        Args:
+        - date: Holiday date
+        - holiday_name: Holiday name
+
+        Returns:
+        - list[str]: List of iCalender format event lines
+        """
+        formatted_date = date.strftime("%Y%m%d")
+        # TODO:implement proper translation logic
+        name = holiday_name
+
+        return [
+            "BEGIN:VEVENT",
+            f"SUMMARY:{name}",
+            f"DTSTART;VALUE=DATE:{formatted_date}",
+            "DURATION:P1D",
+            "END:VEVENT",
+        ]
+
+    def generate(self):
+        """Generate iCalendar data
+
+        Yields:
+        - str: Each line of iCalendar format
+        """
+        yield "BEGIN:VCALENDAR"
+        yield "VERSION:2.0"
+        yield "PRODID:-//holidays Framework//NONSGML v1.9//{self.language.upper()}"
+
+        for date, name in self.holidays.items():
+            yield from self.generate_event(date, name)
+
+        yield "END:VCALENDAR"

--- a/holidays/ical.py
+++ b/holidays/ical.py
@@ -12,16 +12,34 @@
 
 
 class ICalExporter:
-    def __init__(self, holidays_object, language="en", return_bytes=False):
+    def __init__(self, holidays_object, return_bytes=False):
         """Initialize iCalendar exporter
 
         Args:
         - holidays_object: Holidays object containing holiday data
-        - language (str) Output language code (default: 'en')
         - return_bytes(bool): If True, return bytes instead of string
         """
         self.holidays = holidays_object
         self.return_bytes = return_bytes
+
+    def _fold_line(self, line):
+        """Fold long lines according to RFC 5545.
+
+        Lines of text SHOULD NOT be longer than 75 octets.
+        """
+        if len(line.encode("utf-8")) <= 75:
+            return [line]
+
+        result = [line]
+        while len(result[-1].encode("utf-8")) > 75:
+            current = result.pop()
+            pos = 74
+            while len(current[:pos].encode("utf-8")) > 74:
+                pos -= 1
+            result.append(current[:pos])
+            result.append(f" {current[pos:]}")
+
+        return result
 
     def generate_event(self, date, holiday_name):
         """Generate a single holiday event
@@ -34,7 +52,7 @@ class ICalExporter:
         """
         formatted_date = date.strftime("%Y%m%d")
 
-        return [
+        lines = [
             "BEGIN:VEVENT",
             f"SUMMARY:{holiday_name}",
             f"DTSTART;VALUE=DATE:{formatted_date}",
@@ -42,17 +60,28 @@ class ICalExporter:
             "END:VEVENT",
         ]
 
+        folded_lines = []
+        for line in lines:
+            folded_lines.extend(self._fold_line(line))
+
+        return folded_lines
+
     def generate(self):
         """Generate iCalendar data
 
         Yields:
-        - str: Each line of iCalendar format
+        - Union[str, bytes]: Each line of iCalendar format
+            (string or bytes depending on return_bytes)
         """
-        yield "BEGIN:VCALENDAR"
-        yield "VERSION:2.0"
-        yield "PRODID:-//holidays Framework//NONSGML v1.9//EN"
+        lines = []
+        lines.append("BEGIN:VCALENDAR")
+        lines.append("VERSION:2.0")
+        lines.append("PRODID:-//holidays Framework//NONSGML v1.9//EN")
 
         for date, name in self.holidays.items():
-            yield from self.generate_event(date, name)
+            lines.extend(self.generate_event(date, name))
 
-        yield "END:VCALENDAR"
+        lines.append("END:VCALENDAR")
+
+        for line in lines:
+            yield line.encode("utf-8") if self.return_bytes else line

--- a/holidays/ical.py
+++ b/holidays/ical.py
@@ -21,7 +21,6 @@ class ICalExporter:
         - return_bytes(bool): If True, return bytes instead of string
         """
         self.holidays = holidays_object
-        self.language = language
         self.return_bytes = return_bytes
 
     def generate_event(self, date, holiday_name):
@@ -34,12 +33,10 @@ class ICalExporter:
         - list[str]: List of iCalender format event lines
         """
         formatted_date = date.strftime("%Y%m%d")
-        # TODO:implement proper translation logic
-        name = holiday_name
 
         return [
             "BEGIN:VEVENT",
-            f"SUMMARY:{name}",
+            f"SUMMARY:{holiday_name}",
             f"DTSTART;VALUE=DATE:{formatted_date}",
             "DURATION:P1D",
             "END:VEVENT",
@@ -53,7 +50,7 @@ class ICalExporter:
         """
         yield "BEGIN:VCALENDAR"
         yield "VERSION:2.0"
-        yield f"PRODID:-//holidays Framework//NONSGML v1.9//{self.language.upper()}"
+        yield "PRODID:-//holidays Framework//NONSGML v1.9//EN"
 
         for date, name in self.holidays.items():
             yield from self.generate_event(date, name)

--- a/holidays/ical.py
+++ b/holidays/ical.py
@@ -10,6 +10,7 @@
 #  Website: https://github.com/vacanza/holidays
 #  License: MIT (see LICENSE file)
 
+
 class ICalExporter:
     def __init__(self, holidays_object, language="en", return_bytes=False):
         """Initialize iCalendar exporter
@@ -52,7 +53,7 @@ class ICalExporter:
         """
         yield "BEGIN:VCALENDAR"
         yield "VERSION:2.0"
-        yield "PRODID:-//holidays Framework//NONSGML v1.9//{self.language.upper()}"
+        yield f"PRODID:-//holidays Framework//NONSGML v1.9//{self.language.upper()}"
 
         for date, name in self.holidays.items():
             yield from self.generate_event(date, name)

--- a/tests/test_ical.py
+++ b/tests/test_ical.py
@@ -1,0 +1,40 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see AUTHORS file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/holidays
+#  License: MIT (see LICENSE file)
+
+
+from unittest import TestCase
+
+from holidays.countries.us import US
+from holidays.ical import ICalExporter
+
+
+class TestIcalExporter(TestCase):
+    def setUp(self):
+        self.us_holidays = US(years=2024)
+
+    def test_basic_calendar_structure(self):
+        exporter = ICalExporter(self.us_holidays)
+        output = "\n".join(exporter.generate())
+
+        self.assertIn("BEGIN:VCALENDAR", output)
+        self.assertIn("VERSION:2.0", output)
+        self.assertIn("END:VCALENDAR", output)
+
+    def test_single_holiday_event(self):
+        exporter = ICalExporter(self.us_holidays)
+        output = "\n".join(exporter.generate())
+
+        self.assertIn("BEGIN:VEVENT", output)
+        self.assertIn("SUMMARY:New Year's Day", output)
+        self.assertIn("DTSTART;VALUE=DATE:20240101", output)
+        self.assertIn("DURATION:P1D", output)
+        self.assertIn("END:VEVENT", output)

--- a/tests/test_ical.py
+++ b/tests/test_ical.py
@@ -11,30 +11,38 @@
 #  License: MIT (see LICENSE file)
 
 
+from datetime import date
 from unittest import TestCase
 
-from holidays.countries.us import US
 from holidays.ical import ICalExporter
 
 
 class TestIcalExporter(TestCase):
     def setUp(self):
-        self.us_holidays = US(years=2024)
+        self.holidays_data = {
+            date(2024, 1, 1): "New Year's Day",
+            date(2024, 12, 25): "Christmas Day",
+        }
+        self.exporter = ICalExporter(self.holidays_data)
 
     def test_basic_calendar_structure(self):
-        exporter = ICalExporter(self.us_holidays)
-        output = "\n".join(exporter.generate())
+        output = "\n".join(self.exporter.generate())
 
         self.assertIn("BEGIN:VCALENDAR", output)
         self.assertIn("VERSION:2.0", output)
         self.assertIn("END:VCALENDAR", output)
 
     def test_single_holiday_event(self):
-        exporter = ICalExporter(self.us_holidays)
-        output = "\n".join(exporter.generate())
+        output = "\n".join(self.exporter.generate())
 
         self.assertIn("BEGIN:VEVENT", output)
         self.assertIn("SUMMARY:New Year's Day", output)
         self.assertIn("DTSTART;VALUE=DATE:20240101", output)
         self.assertIn("DURATION:P1D", output)
         self.assertIn("END:VEVENT", output)
+
+    def test_localized_holiday_names(self):
+        jp_exporter = ICalExporter(self.holidays_data, language="ja")
+        output = "\n".join(jp_exporter.generate())
+
+        self.assertIn("PRODID:-//holidays Framework//NONSGML v1.9//JA", output)

--- a/tests/test_ical.py
+++ b/tests/test_ical.py
@@ -11,19 +11,16 @@
 #  License: MIT (see LICENSE file)
 
 
-from datetime import date
 from unittest import TestCase
 
+from holidays import country_holidays
 from holidays.ical import ICalExporter
 
 
 class TestIcalExporter(TestCase):
     def setUp(self):
-        self.holidays_data = {
-            date(2024, 1, 1): "New Year's Day",
-            date(2024, 12, 25): "Christmas Day",
-        }
-        self.exporter = ICalExporter(self.holidays_data)
+        self.us_holidays = country_holidays("US", years=2024)
+        self.exporter = ICalExporter(self.us_holidays)
 
     def test_basic_calendar_structure(self):
         output = "\n".join(self.exporter.generate())
@@ -42,7 +39,8 @@ class TestIcalExporter(TestCase):
         self.assertIn("END:VEVENT", output)
 
     def test_localized_holiday_names(self):
-        jp_exporter = ICalExporter(self.holidays_data, language="ja")
+        jp_holidays = country_holidays("JP", years=2024, language="ja")
+        jp_exporter = ICalExporter(jp_holidays)
         output = "\n".join(jp_exporter.generate())
 
-        self.assertIn("PRODID:-//holidays Framework//NONSGML v1.9//JA", output)
+        self.assertIn("SUMMARY:元日", output)

--- a/tests/test_ical.py
+++ b/tests/test_ical.py
@@ -11,6 +11,7 @@
 #  License: MIT (see LICENSE file)
 
 
+from datetime import date
 from unittest import TestCase
 
 from holidays import country_holidays
@@ -38,9 +39,102 @@ class TestIcalExporter(TestCase):
         self.assertIn("DURATION:P1D", output)
         self.assertIn("END:VEVENT", output)
 
+    def test_multiple_holidays_same_date(self):
+        test_multiple_holidays = {date(2024, 1, 1): "Holiday 1; Holiday 2"}
+        exporter = ICalExporter(test_multiple_holidays)
+        output = "\n".join(exporter.generate())
+
+        self.assertIn("Holiday 1", output)
+        self.assertIn("Holiday 2", output)
+
     def test_localized_holiday_names(self):
         jp_holidays = country_holidays("JP", years=2024, language="ja")
         jp_exporter = ICalExporter(jp_holidays)
         output = "\n".join(jp_exporter.generate())
 
         self.assertIn("SUMMARY:元日", output)
+
+    def test_empty_holidays(self):
+        empty_holidays = {}
+        exporter = ICalExporter(empty_holidays)
+        output = "\n".join(exporter.generate())
+
+        self.assertIn("BEGIN:VCALENDAR", output)
+        self.assertIn("VERSION:2.0", output)
+        self.assertIn("END:VCALENDAR", output)
+
+    def test_line_folding_edge_cases(self):
+        line_74_bytes = "x" * 66
+        test_holidays = {date(2024, 1, 1): line_74_bytes}
+        exporter = ICalExporter(test_holidays)
+        output = "\n".join(exporter.generate())
+
+        for line in output.split("\n"):
+            self.assertLessEqual(len(line.encode("utf-8")), 75)
+            if line.startswith(" "):
+                self.assertTrue(line[0].isspace())
+
+        exact_75_bytes = "x" * 72 + "あ"
+        test_holidays = {date(2024, 1, 1): exact_75_bytes}
+        exporter = ICalExporter(test_holidays)
+        output = "\n".join(exporter.generate())
+
+        for line in output.split("\n"):
+            self.assertLessEqual(len(line.encode("utf-8")), 75)
+            if line.startswith(" "):
+                self.assertTrue(line[0].isspace())
+
+        needs_adjustment = "x" * 73 + "あ"
+        test_holidays = {date(2024, 1, 1): needs_adjustment}
+        exporter = ICalExporter(test_holidays)
+        output = "\n".join(exporter.generate())
+
+        for line in output.split("\n"):
+            self.assertLessEqual(len(line.encode("utf-8")), 75)
+            if line.startswith(" "):
+                self.assertTrue(line[0].isspace())
+
+    def test_long_holiday(self):
+        very_long_name = (
+            "This is a very long holiday name that should be folded "
+            "according to RFC 5545 specifications あいうえお"
+        )
+        test_holidays = {date(2024, 1, 1): very_long_name}
+        exporter = ICalExporter(test_holidays)
+        output = "\n".join(exporter.generate())
+
+        for line in output.split("\n"):
+            self.assertLessEqual(len(line.encode("utf-8")), 75)
+
+            if line.startswith(" "):
+                self.assertTrue(line[0].isspace())
+
+    def test_return_bytes(self):
+        test_holidays = {date(2024, 1, 1): "New Year's Day"}
+        exporter = ICalExporter(test_holidays, return_bytes=True)
+        lines = list(exporter.generate())
+
+        for line in lines:
+            self.assertIsInstance(line, bytes)
+            if b"SUMMARY:" in line:
+                self.assertEqual(line, b"SUMMARY:New Year's Day")
+
+        test_holidays = {date(2024, 1, 1): "元日"}
+        exporter = ICalExporter(test_holidays, return_bytes=True)
+        lines = list(exporter.generate())
+
+        for line in lines:
+            self.assertIsInstance(line, bytes)
+            if b"SUMMARY:" in line:
+                self.assertEqual(line, b"SUMMARY:\xe5\x85\x83\xe6\x97\xa5")
+
+    def test_multiple_fold_iterations(self):
+        long_japanese = "あ" * 50
+        test_holidays = {date(2024, 1, 1): long_japanese}
+        exporter = ICalExporter(test_holidays)
+        output = "\n".join(exporter.generate())
+
+        for line in output.split("\n"):
+            self.assertLessEqual(len(line.encode("utf-8")), 75)
+            if line.startswith(" "):
+                self.assertTrue(line[0].isspace())


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change
This PR introduces a new iCalendar export functionality to the holidays library. The implementation includes:

- New `ICalExporter` class for converting holiday data to iCalendar format
- Support for basic iCalendar properties (VCALENDAR, VEVENT)
- Preparation for multi-language support through language parameter
- Test coverage for basic calendar structure and event generation

The exporter follows RFC 5545 specifications for iCalendar format, allowing users to easily export their holiday data to calendar applications.

Example usage:
```python
from holidays import US
from holidays.ical import ICalExporter

us_holidays = US(years=2024)
exporter = ICalExporter(us_holidays)
ical_content = "\n".join(exporter.generate())
```
<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->
Resolves #2179 

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [x] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
