### PR TITLE
Added `get_long_weekends` function to find holiday-based long weekends

### DIFF
--- a/holidays/__init__.py
+++ b/holidays/__init__.py
@@ -18,6 +18,7 @@ from holidays.holiday_base import *
 from holidays.registry import EntityLoader
 from holidays.utils import *
 from holidays.version import __version__  # noqa: F401
+from holidays.long_weekends_finder import*
 
 EntityLoader.load("countries", globals())
 EntityLoader.load("financial", globals())

--- a/holidays/long_weekends_finder.py
+++ b/holidays/long_weekends_finder.py
@@ -1,0 +1,81 @@
+import holidays
+from datetime import timedelta, date
+
+def get_long_weekends(country: str, year: int, month: int = None):
+    """
+    Finds long weekends for a given country and year using the holidays framework.
+
+    :param country: Country code (e.g., 'IN' for India).
+    :param year: Year for which to find long weekends.
+    :param month: Optional month filter (1 for January, 2 for February, etc.).
+    :return: A dictionary containing a list of long weekends.
+    :raises ValueError: If input values are invalid.
+    """
+    
+    # Validate inputs
+    if not isinstance(country, str) or not country:
+        raise ValueError("Country code must be a non-empty string.")
+    
+    if not isinstance(year, int) or year < 1:
+        raise ValueError("Year must be a positive integer.")
+
+    if month is not None:
+        if not isinstance(month, int) or not (1 <= month <= 12):
+            raise ValueError("Month must be an integer between 1 and 12.")
+
+    try:
+        holiday_list = holidays.CountryHoliday(country, years=year)
+    except Exception as e:
+        raise ValueError(f"Invalid country code or error fetching holidays: {str(e)}")
+
+    if month:
+        holiday_list = {date: name for date, name in holiday_list.items() if date.month == month}
+
+    long_weekends = []
+
+    for holiday_date, name in holiday_list.items():
+        # Ensure holiday_date is a valid date object
+        if not isinstance(holiday_date, date):
+            continue
+
+        try:
+            # Check for Friday holidays
+            if holiday_date.weekday() == 4:  # Friday
+                following_monday = holiday_date + timedelta(days=3)
+                if following_monday in holiday_list:
+                    long_weekends.append({
+                        'start_date': holiday_date.strftime('%Y-%m-%d'),
+                        'end_date': following_monday.strftime('%Y-%m-%d'),
+                        'duration': 4,
+                        'holidays': [name, holiday_list[following_monday]],
+                    })
+                else:
+                    long_weekends.append({
+                        'start_date': holiday_date.strftime('%Y-%m-%d'),
+                        'end_date': (holiday_date + timedelta(days=2)).strftime('%Y-%m-%d'),
+                        'duration': 3,
+                        'holidays': [name],
+                    })
+
+            # Check for Monday holidays
+            elif holiday_date.weekday() == 0:  # Monday
+                previous_friday = holiday_date - timedelta(days=3)
+                if previous_friday in holiday_list:
+                    long_weekends.append({
+                        'start_date': previous_friday.strftime('%Y-%m-%d'),
+                        'end_date': holiday_date.strftime('%Y-%m-%d'),
+                        'duration': 4,
+                        'holidays': [holiday_list[previous_friday], name],
+                    })
+                else:
+                    long_weekends.append({
+                        'start_date': (holiday_date - timedelta(days=2)).strftime('%Y-%m-%d'),
+                        'end_date': holiday_date.strftime('%Y-%m-%d'),
+                        'duration': 3,
+                        'holidays': [name],
+                    })
+
+        except Exception as e:
+            print(f"Error processing holiday {holiday_date}: {e}")
+
+    return {"long_weekends": long_weekends}


### PR DESCRIPTION
## Proposed change  

This PR adds a new `get_long_weekends` function, allowing users to find **long weekends** based on public holidays for a given **country, year, and optional month**.  

🔹 Helps users **plan vacations** and **optimize schedules**  
🔹 Supports **3-day and extended 4-day weekends**  
🔹 Ensures **input validation & robust error handling**  

This feature makes it easier to **track holiday-based long weekends** using the `holidays` library.  

## Type of change  

- [x] New feature (new `holidays` functionality in general)  
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)  
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)  
- [ ] Dependency update (version deprecation/pin/upgrade)  
- [ ] Bugfix (non-breaking change which fixes an issue)  
- [ ] Breaking change (a code change causing existing functionality to break)  

## Checklist  

- [x] I've followed the [contributing guidelines][contributing-guidelines]  
- [x] I've successfully run `make check`, and all checks and tests are passing ✅  
