### PR TITLE
Check .mo rather than .po files in TestListLocalizedEntities

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,6 +29,7 @@ Chanran Kim
 Chris McKeague
 Chris Turra
 Christian Alexander
+Colin Watson
 Dan Gentry
 Daniel Musketa
 Daniël Niemeijer

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -148,9 +148,9 @@ class TestListLocalizedEntities(unittest.TestCase):
         for entity_code in supported_entities.keys():
             actual_languages = sorted(
                 # Collect `<locale>` part from
-                # holidays/locale/<locale>/LC_MESSAGES/<country_code>.po.
+                # holidays/locale/<locale>/LC_MESSAGES/<country_code>.mo.
                 path.parts[-3]
-                for path in Path(locale_dir).rglob(f"{entity_code}.po")
+                for path in Path(locale_dir).rglob(f"{entity_code}.mo")
             )
             expected_languages = localized_entities.get(entity_code, [])
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -148,7 +148,7 @@ class TestListLocalizedEntities(unittest.TestCase):
         for entity_code in supported_entities.keys():
             actual_languages = sorted(
                 # Collect `<locale>` part from
-                # holidays/locale/<locale>/LC_MESSAGES/<country_code>.mo.
+                # holidays/locale/<locale>/LC_MESSAGES/<entity_code>.mo.
                 path.parts[-3]
                 for path in Path(locale_dir).rglob(f"{entity_code}.mo")
             )


### PR DESCRIPTION
## Proposed change

Now that `.po` files are no longer included in distribution bundles (https://github.com/vacanza/holidays/pull/2243), having this test look at `.po` files makes things slightly more difficult for downstream distributors such as Debian, since we run the tests on the equivalent of the built wheel.

## Type of change

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green