### PR TITLE
Set correct start date for 2x Historical South Africa holidays

### DIFF
--- a/holidays/countries/south_africa.py
+++ b/holidays/countries/south_africa.py
@@ -87,7 +87,7 @@ class SouthAfrica(ObservedHolidayBase, ChristianHolidays, InternationalHolidays,
         if self._year <= 1951:
             self._add_holiday_may_24("Empire Day")
 
-        if self._year <= 1960:
+        if 1910 <= self._year <= 1960:
             self._add_holiday_may_31("Union Day")
         elif self._year <= 1993:
             self._add_holiday_may_31("Republic Day")
@@ -98,7 +98,7 @@ class SouthAfrica(ObservedHolidayBase, ChristianHolidays, InternationalHolidays,
         if 1961 <= self._year <= 1973:
             self._add_holiday_jul_10("Family Day")
 
-        if self._year <= 1951:
+        if 1910 <= self._year <= 1951:
             self._add_holiday_1st_mon_of_aug("King's Birthday")
 
         if 1952 <= self._year <= 1979:


### PR DESCRIPTION
## Proposed change

South African historical holiday's improvements:
* Union Day started in 1910, the year of the South African Union.
* King's Birthday from 1910.

## Type of change

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
