### PR TITLE
Update Hong Kong holidays: fix `th` l10n typo

### DIFF
--- a/holidays/locale/th/LC_MESSAGES/HK.po
+++ b/holidays/locale/th/LC_MESSAGES/HK.po
@@ -125,7 +125,7 @@ msgstr "วันหลังวันขึ้นปีใหม่"
 
 #. The day following Ching Ming Festival.
 msgid "清明節翌日"
-msgstr "วันหลังวันเช็งเม้ง\""
+msgstr "วันหลังวันเช็งเม้ง"
 
 #. The day following Easter Monday.
 msgid "復活節星期一翌日"


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Fixing `th` l10n typo for Hong Kong.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
