### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,28 +1,38 @@
-## Bug Report
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
 
-### Expected Behavior
+---
 
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
 A clear and concise description of what you expected to happen.
 
-### Actual Behavior
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
 
-A clear and concise description of what actually happened.
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
 
-### Steps to Reproduce the Problem
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
 
-Provide an unambiguous set of steps to reproduce this bug.
-Include code to reproduce, if relevant.
-
-  1.
-  1.
-  1.
-
-### Environment
-
-- OS:
-- Python version:
-- holidays version:
-
-### Additional Context
-
+**Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,11 +11,12 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+Provide an unambiguous set of steps to reproduce this bug.
+Include code to reproduce, if relevant.
+
+1.
+1.
+1.
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
@@ -23,16 +24,11 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+**Environment**
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+- OS:
+- Python version:
+- holidays version:
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,6 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 
 contact_links:
   - name: General question
     url: https://github.com/vacanza/holidays/discussions/new?category=q-a
     about: Ask a question
-
-  - name: Bug Report
-    url: https://github.com/vacanza/holidays/issues/new?template=bug_report.md
-    about: Report an issue
-
-  - name: Feature Request
-    url: https://github.com/vacanza/holidays/issues/new?template=feature_request.md
-    about: Suggest an idea

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,17 +1,20 @@
-## Feature Request
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
 
-### Description
+---
 
-A clear and concise description of the feature you are requesting.
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-### Related Issues
-
-List any related issues or feature requests that might be relevant.
-
-### Proposed Solution
-
+**Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 
-### Additional context
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
 
-Add any other context about your feature request here.
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
I'm trying to fix this behavior upon "New Issue" button click.

<img width="1507" alt="Screenshot 2025-02-21 at 4 39 02 PM" src="https://github.com/user-attachments/assets/48c02159-3c10-4718-bfe2-7d4cee5f9aad" />


The changes originally auto-generated by GitHub wizard here

<img width="1631" alt="Screenshot 2025-02-21 at 4 40 55 PM" src="https://github.com/user-attachments/assets/1f83ee8c-6454-4430-a094-033989f388ee" />


and updated manually. Let's try and see if that fixes the problem.