### PR TITLE
Update Philippines holidays:  adjust Bonifacio Day for 2023

### DIFF
--- a/holidays/countries/philippines.py
+++ b/holidays/countries/philippines.py
@@ -47,6 +47,7 @@ class Philippines(
       - `Republic Act No. 10966 <https://www.officialgazette.gov.ph/2017/12/28/republic-act-no-10966/>`_
       - `Proclamation No. 944/2020` <https://www.officialgazette.gov.ph/2020/05/19/proclamation-no-944-s-2020/>`_
       - `Proclamation No. 985/2020` <https://www.officialgazette.gov.ph/2020/07/29/proclamation-no-985-s-2020/>`_
+      - `Proclamation No. 90/2022` <https://www.officialgazette.gov.ph/2022/11/09/proclamation-no-90-s-2022/>`_
       - `Proclamation No. 665/2024` <https://www.officialgazette.gov.ph/2024/08/15/proclamation-no-665-s-2024/>`_
       - `Proclamation No. 729/2024` <https://www.officialgazette.gov.ph/2024/10/30/proclamation-no-729-s-2024/>`_
       - `Nationwide holidays 2018-2025 <https://www.officialgazette.gov.ph/nationwide-holidays/2018/>`_
@@ -146,6 +147,7 @@ class Philippines(
         dates_obs = {
             2008: (DEC, 1),
             2010: (NOV, 29),
+            2023: (NOV, 27),
         }
         # Bonifacio Day.
         self._add_holiday(tr("Bonifacio Day"), dates_obs.get(self._year, (NOV, 30)))

--- a/tests/countries/test_philippines.py
+++ b/tests/countries/test_philippines.py
@@ -238,10 +238,11 @@ class TestPhilippines(CommonCountryTests, TestCase):
         name = "Bonifacio Day"
         self.assertHolidayName(
             name,
-            (f"{year}-11-30" for year in (*range(1988, 2008), *range(2011, 2050))),
+            (f"{year}-11-30" for year in (*range(1988, 2008), *range(2011, 2023), *range(2024, 2050))),
             "2008-12-01",
             "2009-11-30",
             "2010-11-29",
+            "2023-11-27",
         )
 
     def test_immaculate_conception_day(self):

--- a/tests/countries/test_philippines.py
+++ b/tests/countries/test_philippines.py
@@ -451,7 +451,7 @@ class TestPhilippines(CommonCountryTests, TestCase):
             ("2023-10-30", "Elections special (non-working) day"),
             ("2023-11-01", "All Saints' Day"),
             ("2023-11-02", "Additional special (non-working) day"),
-            ("2023-11-30", "Bonifacio Day"),
+            ("2023-11-27", "Bonifacio Day"),
             ("2023-12-08", "Feast of the Immaculate Conception of Mary"),
             ("2023-12-25", "Christmas Day"),
             ("2023-12-26", "Additional special (non-working) day"),

--- a/tests/countries/test_philippines.py
+++ b/tests/countries/test_philippines.py
@@ -238,7 +238,10 @@ class TestPhilippines(CommonCountryTests, TestCase):
         name = "Bonifacio Day"
         self.assertHolidayName(
             name,
-            (f"{year}-11-30" for year in (*range(1988, 2008), *range(2011, 2023), *range(2024, 2050))),
+            (
+                f"{year}-11-30"
+                for year in (*range(1988, 2008), *range(2011, 2023), *range(2024, 2050))
+            ),
             "2008-12-01",
             "2009-11-30",
             "2010-11-29",


### PR DESCRIPTION
## Proposed change
Adjust the Philippines holiday Bonifacio Day for 2023. 
Bonifacio Day was moved from 2023-11-30 to 2023-11-27.

Source:
https://www.officialgazette.gov.ph/2022/11/09/proclamation-no-90-s-2022/

## Type of change

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green
