### PR TITLE
Added commit SHAs instead of versions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -63,7 +63,7 @@ jobs:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@70df9def86d22bf0ea4e7f8b956e7b92e7c1ea22
+        uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841
         with:
           category: '/language:python'
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,16 +35,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
         with:
           check-latest: true
           python-version: '3.13'
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
 
   code-ql:
     name: CodeQL
@@ -55,15 +55,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@70df9def86d22bf0ea4e7f8b956e7b92e7c1ea22
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@70df9def86d22bf0ea4e7f8b956e7b92e7c1ea22
         with:
           category: '/language:python'
 
@@ -86,10 +86,10 @@ jobs:
           - '3.13'
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
         with:
           allow-prereleases: true
           cache: pip
@@ -110,7 +110,7 @@ jobs:
           make test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -120,10 +120,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
         with:
           cache: pip
           cache-dependency-path: |
@@ -142,7 +142,7 @@ jobs:
           make package
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: dist
           path: dist
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload SBOM
         if: startsWith(github.event.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: sbom
           path: holidays-${{ env.VERSION }}-sbom.json
@@ -175,10 +175,10 @@ jobs:
           - windows-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
         with:
           cache: pip
           cache-dependency-path: |
@@ -188,7 +188,7 @@ jobs:
           python-version: '3.13'
 
       - name: Get package artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
           name: dist
           path: dist
@@ -210,10 +210,10 @@ jobs:
     needs: test
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set Up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
         with:
           cache: pip
           cache-dependency-path: requirements/docs.txt
@@ -244,13 +244,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download package artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
           name: dist
           path: dist
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
 
   sign-artifacts:
     name: Create SHA1 checksums and Sigstore signatures
@@ -261,7 +261,7 @@ jobs:
       id-token: write
     steps:
       - name: Download package artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
           name: dist
           path: dist
@@ -274,14 +274,14 @@ jobs:
           done
 
       - name: Sign the files using Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46
         with:
           inputs: |
             ./dist/*.tar.gz
             ./dist/*.whl
 
       - name: Upload package dist and signatures
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: signed-artifacts
           path: dist
@@ -295,12 +295,12 @@ jobs:
       contents: write
     steps:
       - name: Download SBOM
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
           name: sbom
 
       - name: Download package dist and signatures
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
           name: signed-artifacts
           path: dist

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@70df9def86d22bf0ea4e7f8b956e7b92e7c1ea22
+        uses: github/codeql-action/init@1b549b9259bda1cb5ddde3b41741a82a2d15a841
         with:
           languages: python
 

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -17,9 +17,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
         with:
           cache: pip
           python-version: '3.12'
@@ -29,7 +29,7 @@ jobs:
           python -m pip install pre-commit
 
       - name: Use pre-commit environment cache
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
           path: ~/.cache/pre-commit
@@ -40,7 +40,7 @@ jobs:
           pre-commit autoupdate
           pre-commit run --all-files
 
-      - uses: peter-evans/create-pull-request@v7.0.8
+      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
           base: dev
           body: Update pre-commit hooks to their latest versions.

--- a/.github/workflows/prl-labeler.yml
+++ b/.github/workflows/prl-labeler.yml
@@ -10,4 +10,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
         with:
           cache: pip
           cache-dependency-path: |
@@ -38,7 +38,7 @@ jobs:
         run: |
           make snapshot
 
-      - uses: peter-evans/create-pull-request@v7.0.8
+      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
           base: dev
           body: Automatically generated snapshots update.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,15 +105,19 @@ MkDocs, you can read a primer [here](https://www.mkdocs.org/user-guide/writing-y
 
 ## GitHub Actions
 
-All new GitHub Actions must use commit SHAs instead of version tags. When updating an action, contributors should explicitly use the commit SHA from the latest release.
+All new GitHub actions must use commit SHAs instead of version tags. When updating an action, contributors should explicitly use the commit SHA from the latest release.
 
 ### Example
 
-``` shell
-# Allowed:
-uses: actions/checkout@8fdb40e56baf9c5dc24e3ab5bc2a91db65f39f21
+Allowed:
 
-# Not allowed:
+```yaml
+uses: actions/checkout@8fdb40e56baf9c5dc24e3ab5bc2a91db65f39f21
+```
+
+Not allowed:
+
+```yaml
 uses: actions/checkout@v4
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,18 @@ The project provides MkDocs documentation under `./docs`, published online on
 Great documentation is absolutely key in any project. If you are not familiar with Markdown for
 MkDocs, you can read a primer [here](https://www.mkdocs.org/user-guide/writing-your-docs/).
 
+## GitHub Actions
+
+All new GitHub Actions must use commit SHAs instead of version tags. When updating an action, contributors should explicitly use the commit SHA from the latest release.
+
+### Example
+```
+# Allowed:
+uses: actions/checkout@8fdb40e56baf9c5dc24e3ab5bc2a91db65f39f21
+
+# Not allowed:
+uses: actions/checkout@v4
+```
 ## Contributors
 
 In order to keep the list of contributors up to date, we encourage you add your name (in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,13 +108,15 @@ MkDocs, you can read a primer [here](https://www.mkdocs.org/user-guide/writing-y
 All new GitHub Actions must use commit SHAs instead of version tags. When updating an action, contributors should explicitly use the commit SHA from the latest release.
 
 ### Example
-```
+
+``` shell
 # Allowed:
 uses: actions/checkout@8fdb40e56baf9c5dc24e3ab5bc2a91db65f39f21
 
 # Not allowed:
 uses: actions/checkout@v4
 ```
+
 ## Contributors
 
 In order to keep the list of contributors up to date, we encourage you add your name (in


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Closes: #2343 
Added commit SHAs instead of versions in workflow files.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [x] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
