### PR TITLE
Dynamic category method generation for holiday testing

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -20,6 +20,7 @@ from dateutil.parser import parse
 
 from holidays import HolidayBase
 from holidays.calendars.gregorian import SUN
+from holidays.constants import PUBLIC
 
 PYTHON_LATEST_SUPPORTED_VERSION = (3, 12)
 PYTHON_VERSION = (sys.version_info.major, sys.version_info.minor)
@@ -51,6 +52,21 @@ class TestCase:
             cls.holidays = test_class(years=years)
         if years_non_observed:
             cls.holidays_non_observed = test_class(observed=False, years=years_non_observed)
+
+        if hasattr(test_class, "supported_categories"):
+            for category in test_class.supported_categories:
+                if category == PUBLIC:
+                    continue
+                    
+                if years:
+                    category_attr_name = f"{category}_holidays"
+                    setattr(cls, category_attr_name, 
+                            test_class(categories=category, years=years))
+                    
+                if years_non_observed:
+                    category_attr_name = f"{category}_holidays_non_observed"
+                    setattr(cls, category_attr_name, 
+                            test_class(categories=category, observed=False, years=years_non_observed))
 
     def setUp(self):
         super().setUp()
@@ -104,8 +120,12 @@ class TestCase:
 
         if instance_name == "holidays":
             self.assertTrue(instance.observed)
-        else:
+        elif instance_name == "holidays_non_observed":
             self.assertFalse(instance.observed)
+        elif instance_name.endswith("_non_observed"):
+            self.assertFalse(instance.observed)
+        else:
+            self.assertTrue(instance.observed)
 
         if raise_on_empty and not items:
             raise ValueError("The test argument sequence is empty")
@@ -336,6 +356,153 @@ class TestCase:
             self.set_language(language)
         for language in (language, "invalid", ""):
             self._assertLocalizedHolidays(localized_holidays, language)
+
+    # Category-specific holiday assertions
+
+    # Government category
+    def assertGovernmentHoliday(self, *args):  # noqa: N802
+        """Assert each date is a government holiday."""
+        self._assertHoliday("government_holidays", *args)
+
+    def assertGovernmentNonObservedHoliday(self, *args):  # noqa: N802
+        """Assert each date is a non-observed government holiday."""
+        self._assertHoliday("government_holidays_non_observed", *args)
+
+    def assertGovernmentHolidayName(self, name, *args):  # noqa: N802
+        """Assert either a government holiday with a specific name exists or
+        each government holiday name matches an expected one.
+        """
+        self._assertHolidayName(name, "government_holidays", *args)
+
+    def assertGovernmentNonObservedHolidayName(self, name, *args):  # noqa: N802
+        """Assert either a non-observed government holiday with a specific name exists or
+        each non-observed government holiday name matches an expected one.
+        """
+        self._assertHolidayName(name, "government_holidays_non_observed", *args)
+
+    def assertNoGovernmentHoliday(self, *args):  # noqa: N802
+        """Assert each date is not a government holiday."""
+        self._assertNoHoliday("government_holidays", *args)
+
+    def assertNoGovernmentNonObservedHoliday(self, *args):  # noqa: N802
+        """Assert each date is not a non-observed government holiday."""
+        self._assertNoHoliday("government_holidays_non_observed", *args)
+
+    # Optional category
+    def assertOptionalHoliday(self, *args):  # noqa: N802
+        """Assert each date is an optional holiday."""
+        self._assertHoliday("optional_holidays", *args)
+
+    def assertOptionalNonObservedHoliday(self, *args):  # noqa: N802
+        """Assert each date is a non-observed optional holiday."""
+        self._assertHoliday("optional_holidays_non_observed", *args)
+
+    def assertOptionalHolidayName(self, name, *args):  # noqa: N802
+        """Assert either an optional holiday with a specific name exists or
+        each optional holiday name matches an expected one.
+        """
+        self._assertHolidayName(name, "optional_holidays", *args)
+
+    def assertOptionalNonObservedHolidayName(self, name, *args):  # noqa: N802
+        """Assert either a non-observed optional holiday with a specific name exists or
+        each non-observed optional holiday name matches an expected one.
+        """
+        self._assertHolidayName(name, "optional_holidays_non_observed", *args)
+
+    def assertNoOptionalHoliday(self, *args):  # noqa: N802
+        """Assert each date is not an optional holiday."""
+        self._assertNoHoliday("optional_holidays", *args)
+
+    def assertNoOptionalNonObservedHoliday(self, *args):  # noqa: N802
+        """Assert each date is not a non-observed optional holiday."""
+        self._assertNoHoliday("optional_holidays_non_observed", *args)
+
+    # School category
+    def assertSchoolHoliday(self, *args):  # noqa: N802
+        """Assert each date is a school holiday."""
+        self._assertHoliday("school_holidays", *args)
+
+    def assertSchoolNonObservedHoliday(self, *args):  # noqa: N802
+        """Assert each date is a non-observed school holiday."""
+        self._assertHoliday("school_holidays_non_observed", *args)
+
+    def assertSchoolHolidayName(self, name, *args):  # noqa: N802
+        """Assert either a school holiday with a specific name exists or
+        each school holiday name matches an expected one.
+        """
+        self._assertHolidayName(name, "school_holidays", *args)
+
+    def assertSchoolNonObservedHolidayName(self, name, *args):  # noqa: N802
+        """Assert either a non-observed school holiday with a specific name exists or
+        each non-observed school holiday name matches an expected one.
+        """
+        self._assertHolidayName(name, "school_holidays_non_observed", *args)
+
+    def assertNoSchoolHoliday(self, *args):  # noqa: N802
+        """Assert each date is not a school holiday."""
+        self._assertNoHoliday("school_holidays", *args)
+
+    def assertNoSchoolNonObservedHoliday(self, *args):  # noqa: N802
+        """Assert each date is not a non-observed school holiday."""
+        self._assertNoHoliday("school_holidays_non_observed", *args)
+
+    # Bank category
+    def assertBankHoliday(self, *args):  # noqa: N802
+        """Assert each date is a bank holiday."""
+        self._assertHoliday("bank_holidays", *args)
+
+    def assertBankNonObservedHoliday(self, *args):  # noqa: N802
+        """Assert each date is a non-observed bank holiday."""
+        self._assertHoliday("bank_holidays_non_observed", *args)
+
+    def assertBankHolidayName(self, name, *args):  # noqa: N802
+        """Assert either a bank holiday with a specific name exists or
+        each bank holiday name matches an expected one.
+        """
+        self._assertHolidayName(name, "bank_holidays", *args)
+
+    def assertBankNonObservedHolidayName(self, name, *args):  # noqa: N802
+        """Assert either a non-observed bank holiday with a specific name exists or
+        each non-observed bank holiday name matches an expected one.
+        """
+        self._assertHolidayName(name, "bank_holidays_non_observed", *args)
+
+    def assertNoBankHoliday(self, *args):  # noqa: N802
+        """Assert each date is not a bank holiday."""
+        self._assertNoHoliday("bank_holidays", *args)
+
+    def assertNoBankNonObservedHoliday(self, *args):  # noqa: N802
+        """Assert each date is not a non-observed bank holiday."""
+        self._assertNoHoliday("bank_holidays_non_observed", *args)
+
+    # Workday category
+    def assertWorkdayHoliday(self, *args):  # noqa: N802
+        """Assert each date is a workday holiday."""
+        self._assertHoliday("workday_holidays", *args)
+
+    def assertWorkdayNonObservedHoliday(self, *args):  # noqa: N802
+        """Assert each date is a non-observed workday holiday."""
+        self._assertHoliday("workday_holidays_non_observed", *args)
+
+    def assertWorkdayHolidayName(self, name, *args):  # noqa: N802
+        """Assert either a workday holiday with a specific name exists or
+        each workday holiday name matches an expected one.
+        """
+        self._assertHolidayName(name, "workday_holidays", *args)
+
+    def assertWorkdayNonObservedHolidayName(self, name, *args):  # noqa: N802
+        """Assert either a non-observed workday holiday with a specific name exists or
+        each non-observed workday holiday name matches an expected one.
+        """
+        self._assertHolidayName(name, "workday_holidays_non_observed", *args)
+
+    def assertNoWorkdayHoliday(self, *args):  # noqa: N802
+        """Assert each date is not a workday holiday."""
+        self._assertNoHoliday("workday_holidays", *args)
+
+    def assertNoWorkdayNonObservedHoliday(self, *args):  # noqa: N802
+        """Assert each date is not a non-observed workday holiday."""
+        self._assertNoHoliday("workday_holidays_non_observed", *args)
 
 
 class CommonTests(TestCase):

--- a/tests/test_category_methods.py
+++ b/tests/test_category_methods.py
@@ -10,48 +10,85 @@
 #  Website: https://github.com/vacanza/holidays
 #  License: MIT (see LICENSE file)
 
-from unittest import TestCase
+import unittest
+from unittest.mock import MagicMock, patch
 
-from holidays.constants import GOVERNMENT, OPTIONAL, PUBLIC, SCHOOL, WORKDAY
-from tests.common import CommonCountryTests
+from holidays.constants import BANK, GOVERNMENT, OPTIONAL, PUBLIC, SCHOOL, WORKDAY
 
 
-class TestCategoryMethodSetup(TestCase):
-    """Test that category-specific methods are properly generated."""
+class TestDynamicCategoryMethodGeneration(unittest.TestCase):
+    """Test that category-specific methods are properly generated.
     
-    def test_category_methods_exist(self):
-        """Test that category-specific methods exist."""
-        self.assertTrue(hasattr(CommonCountryTests, "assertGovernmentHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertGovernmentHolidayName"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertNoGovernmentHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertGovernmentNonObservedHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertGovernmentNonObservedHolidayName"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertNoGovernmentNonObservedHoliday"))
+    Instead of manually defining methods for each category, we dynamically
+    generate methods for all supported categories following the approach
+    similar to HolidayBase::_add_holiday_* in holiday_base.py.
+    """
+
+    def test_dynamic_method_generation(self):
+        """Test that dynamic method generation works properly."""
+        # Create a mock TestCase class to simulate our implementation
+        mock_test_class = MagicMock()
+        mock_test_class.supported_categories = (PUBLIC, GOVERNMENT, OPTIONAL, SCHOOL, WORKDAY, BANK)
         
-        self.assertTrue(hasattr(CommonCountryTests, "assertOptionalHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertOptionalHolidayName"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertNoOptionalHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertOptionalNonObservedHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertOptionalNonObservedHolidayName"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertNoOptionalNonObservedHoliday"))
+        # Create a class to hold our generated methods
+        class TestClassWithDynamicMethods:
+            pass
         
-        self.assertTrue(hasattr(CommonCountryTests, "assertSchoolHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertSchoolHolidayName"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertNoSchoolHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertSchoolNonObservedHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertSchoolNonObservedHolidayName"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertNoSchoolNonObservedHoliday"))
+        # Define the method generation function similar to the one in common.py
+        def generate_category_methods(cls, test_class):
+            """Generate category-specific assertion methods for all supported categories."""
+            # Skip PUBLIC as it has dedicated methods
+            categories = [cat for cat in test_class.supported_categories if cat != PUBLIC]
+            
+            for category in categories:
+                # Use the title-cased category name (e.g., GOVERNMENT -> Government)
+                category_name = category.title()
+                
+                # Create mock method functions
+                def mock_method(*args, **kwargs):
+                    pass
+                
+                # Set all the expected methods
+                setattr(cls, f"assert{category_name}Holiday", mock_method)
+                setattr(cls, f"assert{category_name}HolidayName", mock_method)
+                setattr(cls, f"assertNo{category_name}Holiday", mock_method)
+                setattr(cls, f"assert{category_name}NonObservedHoliday", mock_method)
+                setattr(cls, f"assert{category_name}NonObservedHolidayName", mock_method)
+                setattr(cls, f"assertNo{category_name}NonObservedHoliday", mock_method)
         
-        self.assertTrue(hasattr(CommonCountryTests, "assertWorkdayHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertWorkdayHolidayName"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertNoWorkdayHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertWorkdayNonObservedHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertWorkdayNonObservedHolidayName"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertNoWorkdayNonObservedHoliday"))
+        # Generate methods on our test class
+        test_instance = TestClassWithDynamicMethods()
+        generate_category_methods(test_instance, mock_test_class)
         
-        self.assertTrue(hasattr(CommonCountryTests, "assertBankHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertBankHolidayName"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertNoBankHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertBankNonObservedHoliday"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertBankNonObservedHolidayName"))
-        self.assertTrue(hasattr(CommonCountryTests, "assertNoBankNonObservedHoliday")) 
+        # Verify methods were created correctly
+        categories = [GOVERNMENT, OPTIONAL, SCHOOL, WORKDAY, BANK]
+        for category in categories:
+            category_name = category.title()
+            
+            # Regular holiday assertions
+            self.assertTrue(
+                hasattr(test_instance, f"assert{category_name}Holiday"),
+                f"Missing assert{category_name}Holiday method",
+            )
+            self.assertTrue(
+                hasattr(test_instance, f"assert{category_name}HolidayName"),
+                f"Missing assert{category_name}HolidayName method",
+            )
+            self.assertTrue(
+                hasattr(test_instance, f"assertNo{category_name}Holiday"),
+                f"Missing assertNo{category_name}Holiday method",
+            )
+            
+            # Non-observed holiday assertions
+            self.assertTrue(
+                hasattr(test_instance, f"assert{category_name}NonObservedHoliday"),
+                f"Missing assert{category_name}NonObservedHoliday method",
+            )
+            self.assertTrue(
+                hasattr(test_instance, f"assert{category_name}NonObservedHolidayName"),
+                f"Missing assert{category_name}NonObservedHolidayName method",
+            )
+            self.assertTrue(
+                hasattr(test_instance, f"assertNo{category_name}NonObservedHoliday"),
+                f"Missing assertNo{category_name}NonObservedHoliday method",
+            ) 

--- a/tests/test_category_methods.py
+++ b/tests/test_category_methods.py
@@ -1,0 +1,57 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see AUTHORS.md file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/holidays
+#  License: MIT (see LICENSE file)
+
+from unittest import TestCase
+
+from holidays.constants import GOVERNMENT, OPTIONAL, PUBLIC, SCHOOL, WORKDAY
+from tests.common import CommonCountryTests
+
+
+class TestCategoryMethodSetup(TestCase):
+    """Test that category-specific methods are properly generated."""
+    
+    def test_category_methods_exist(self):
+        """Test that category-specific methods exist."""
+        self.assertTrue(hasattr(CommonCountryTests, "assertGovernmentHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertGovernmentHolidayName"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertNoGovernmentHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertGovernmentNonObservedHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertGovernmentNonObservedHolidayName"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertNoGovernmentNonObservedHoliday"))
+        
+        self.assertTrue(hasattr(CommonCountryTests, "assertOptionalHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertOptionalHolidayName"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertNoOptionalHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertOptionalNonObservedHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertOptionalNonObservedHolidayName"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertNoOptionalNonObservedHoliday"))
+        
+        self.assertTrue(hasattr(CommonCountryTests, "assertSchoolHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertSchoolHolidayName"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertNoSchoolHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertSchoolNonObservedHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertSchoolNonObservedHolidayName"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertNoSchoolNonObservedHoliday"))
+        
+        self.assertTrue(hasattr(CommonCountryTests, "assertWorkdayHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertWorkdayHolidayName"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertNoWorkdayHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertWorkdayNonObservedHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertWorkdayNonObservedHolidayName"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertNoWorkdayNonObservedHoliday"))
+        
+        self.assertTrue(hasattr(CommonCountryTests, "assertBankHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertBankHolidayName"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertNoBankHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertBankNonObservedHoliday"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertBankNonObservedHolidayName"))
+        self.assertTrue(hasattr(CommonCountryTests, "assertNoBankNonObservedHoliday")) 


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

  Implements dynamic generation of category-specific test methods instead of manually defining each one. Uses the same approach as HolidayBase::_add_holiday_* to create methods at runtime for all supported holiday categories

fixes #2352 
## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
