### PR TITLE
Introduced Pakistan Subdivisions and Province-Specific Holidays

### DIFF
--- a/holidays/countries/pakistan.py
+++ b/holidays/countries/pakistan.py
@@ -106,14 +106,21 @@ class Pakistan(HolidayBase, InternationalHolidays, IslamicHolidays):
 
         
         # Ensure self.subdiv is not None before checking specific values
-        if not self.subdiv:
-            return  # No subdivisions selected, so no need to add local holidays
+        # Adding province/city-specific holidays based on self.subdiv
+    if not hasattr(self, "subdiv") or self.subdiv is None:
+        return
 
-        if self.subdiv == "PB":  # Punjab
-            self._add_holiday_mar_29(tr("Mela Chiraghan"))  # Lahore Only
+    if self.subdiv == "PB":  # Punjab
+        self._add_holiday_mar_29(tr("Mela Chiraghan"))  # Lahore Only
 
-        if self.subdiv == "SD":  # Sindh
-            self._add_holiday_dec_27(tr("Benazir Bhutto's Martyrdom Day"))
+    if self.subdiv == "SD":  # Sindh
+        self._add_holiday_dec_27(tr("Benazir Bhutto’s Martyrdom Day"))
+
+    if self.subdiv == "PB":  # Punjab
+        self._add_holiday_mar_29(tr("Mela Chiraghan"))  # Lahore Only
+
+    if self.subdiv == "SD":  # Sindh
+        self._add_holiday_dec_27(tr("Benazir Bhutto's Martyrdom Day"))
 
 class PK(Pakistan):
     pass

--- a/holidays/countries/pakistan.py
+++ b/holidays/countries/pakistan.py
@@ -103,24 +103,21 @@ class Pakistan(HolidayBase, InternationalHolidays, IslamicHolidays):
 
     def _populate_subdiv_holidays(self):
         # Adding province/city-specific holidays based on self.subdiv
-
-        
         # Ensure self.subdiv is not None before checking specific values
-        # Adding province/city-specific holidays based on self.subdiv
-    if not hasattr(self, "subdiv") or self.subdiv is None:
-        return
-
-    if self.subdiv == "PB":  # Punjab
-        self._add_holiday_mar_29(tr("Mela Chiraghan"))  # Lahore Only
-
-    if self.subdiv == "SD":  # Sindh
-        self._add_holiday_dec_27(tr("Benazir Bhutto’s Martyrdom Day"))
-
-    if self.subdiv == "PB":  # Punjab
-        self._add_holiday_mar_29(tr("Mela Chiraghan"))  # Lahore Only
-
-    if self.subdiv == "SD":  # Sindh
-        self._add_holiday_dec_27(tr("Benazir Bhutto's Martyrdom Day"))
+        if not hasattr(self, "subdiv") or self.subdiv is None:
+            return
+    
+        if self.subdiv == "PB":  # Punjab
+            self._add_holiday_mar_29(tr("Mela Chiraghan"))  # Lahore Only
+    
+        if self.subdiv == "SD":  # Sindh
+            self._add_holiday_dec_27(tr("Benazir Bhutto’s Martyrdom Day"))
+    
+        if self.subdiv == "PB":  # Punjab
+            self._add_holiday_mar_29(tr("Mela Chiraghan"))  # Lahore Only
+    
+        if self.subdiv == "SD":  # Sindh
+            self._add_holiday_dec_27(tr("Benazir Bhutto's Martyrdom Day"))
 
 class PK(Pakistan):
     pass

--- a/holidays/countries/pakistan.py
+++ b/holidays/countries/pakistan.py
@@ -107,7 +107,7 @@ class Pakistan(HolidayBase, InternationalHolidays, IslamicHolidays):
         
         # Ensure self.subdiv is not None before checking specific values
         if not self.subdiv:
-        return  # No subdivisions selected, so no need to add local holidays
+            return  # No subdivisions selected, so no need to add local holidays
 
         if self.subdiv == "PB":  # Punjab
             self._add_holiday_mar_29(tr("Mela Chiraghan"))  # Lahore Only

--- a/holidays/countries/pakistan.py
+++ b/holidays/countries/pakistan.py
@@ -25,7 +25,6 @@ class Pakistan(HolidayBase, InternationalHolidays, IslamicHolidays):
         * <https://en.wikipedia.org/wiki/Public_holidays_in_Pakistan>
         * <https://ur.wikipedia.org/wiki/تعطیلات_پاکستان>
     """
-    
     country = "PK"
     default_language = "en_PK"
     # %s (estimated).
@@ -100,10 +99,16 @@ class Pakistan(HolidayBase, InternationalHolidays, IslamicHolidays):
         self._add_ashura_eve(name)
         self._add_ashura_day(name)
 
-    self._populate_subdiv_holidays()
+        self._populate_subdiv_holidays()
 
     def _populate_subdiv_holidays(self):
         # Adding province/city-specific holidays based on self.subdiv
+
+        
+        # Ensure self.subdiv is not None before checking specific values
+        if not self.subdiv:
+        return  # No subdivisions selected, so no need to add local holidays
+
         if self.subdiv == "PB":  # Punjab
             self._add_holiday_mar_29(tr("Mela Chiraghan"))  # Lahore Only
 

--- a/holidays/countries/pakistan.py
+++ b/holidays/countries/pakistan.py
@@ -25,7 +25,7 @@ class Pakistan(HolidayBase, InternationalHolidays, IslamicHolidays):
         * <https://en.wikipedia.org/wiki/Public_holidays_in_Pakistan>
         * <https://ur.wikipedia.org/wiki/تعطیلات_پاکستان>
     """
-
+    
     country = "PK"
     default_language = "en_PK"
     # %s (estimated).
@@ -33,6 +33,17 @@ class Pakistan(HolidayBase, InternationalHolidays, IslamicHolidays):
     start_year = 1948
     supported_languages = ("en_PK", "en_US", "ur_PK")
 
+    subdivisions = {
+    "PB": "Punjab",
+    "SD": "Sindh",
+    "KP": "Khyber Pakhtunkhwa",
+    "BA": "Balochistan",
+    "GB": "Gilgit-Baltistan",
+    "AJK": "Azad Jammu & Kashmir",
+    "ICT": "Islamabad Capital Territory",
+    }
+    
+    
     def __init__(self, islamic_show_estimated: bool = True, *args, **kwargs):
         """
         Args:
@@ -89,6 +100,15 @@ class Pakistan(HolidayBase, InternationalHolidays, IslamicHolidays):
         self._add_ashura_eve(name)
         self._add_ashura_day(name)
 
+    self._populate_subdiv_holidays()
+
+    def _populate_subdiv_holidays(self):
+        # Adding province/city-specific holidays based on self.subdiv
+        if self.subdiv == "PB":  # Punjab
+            self._add_holiday_mar_29(tr("Mela Chiraghan"))  # Lahore Only
+
+        if self.subdiv == "SD":  # Sindh
+            self._add_holiday_dec_27(tr("Benazir Bhutto's Martyrdom Day"))
 
 class PK(Pakistan):
     pass


### PR DESCRIPTION
**Proposed Change**

    Added subdivisions for Pakistan, including Punjab, Sindh, Khyber Pakhtunkhwa, Balochistan, Gilgit-Baltistan, Azad Jammu & Kashmir, and Islamabad.

1.  Implemented _populate_subdiv_holidays() to handle province-specific holidays.
2.  Added Mela Chiraghan (March 29) as a localized holiday for Lahore (Punjab).
3.  Ensured self.subdiv is properly checked before assigning regional holidays.
4.  Maintained backward compatibility while improving holiday data granularity.

**Type of Change**

1. Supported country/market holidays update (calendar discrepancy fix, localization)
2. New feature (new holidays functionality in general)

**Checklist**

1. Followed the contributing guidelines.

2. Successfully ran make check, ensuring all tests pass.
