### PR TITLE
Add Turks and Caicos Islands holidays

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -132,6 +132,7 @@ Santiago Feliu
 Sergi Almacellas Abellana
 Sergio Mayoral Martinez
 Serhii Murza
+Shalom Donga
 Shaurya Uppal
 Sho Hirose
 Simon Gurcke

--- a/README.md
+++ b/README.md
@@ -1220,6 +1220,13 @@ any) in brackets, available languages and additional holiday categories. All cou
 <td>HALF_DAY</td>
 </tr>
 <tr>
+<td>Turks and Caicos Islands</td>
+<td>TC</td>
+<td></td>
+<td><strong>en_US</strong></td>
+<td></td>
+</tr>
+<tr>
 <td>Tuvalu</td>
 <td>TV</td>
 <td>Town/Island Councils: FUN (Funafuti), NIT (Niutao), NKF (Nukufetau), NKL (Nukulaelae), NMA (Nanumea), NMG (Nanumaga, Nanumanga), NUI (Nui), VAI (Vaitupu)</td>

--- a/holidays/countries/__init__.py
+++ b/holidays/countries/__init__.py
@@ -166,6 +166,7 @@ from .timor_leste import TimorLeste, TL, TLS
 from .tonga import Tonga, TO, TON
 from .tunisia import Tunisia, TN, TUN
 from .turkey import Turkey, TR, TUR
+from .turks_and_caicos_islands import TurksAndCaicosIslands, TC, TCA
 from .tuvalu import Tuvalu, TV, TUV
 from .ukraine import Ukraine, UA, UKR
 from .united_arab_emirates import UnitedArabEmirates, AE, ARE

--- a/holidays/countries/turks_and_caicos_islands.py
+++ b/holidays/countries/turks_and_caicos_islands.py
@@ -1,0 +1,81 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see AUTHORS.md file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/holidays
+#  License: MIT (see LICENSE file)
+
+from gettext import gettext as tr
+
+from holidays.constants import JAN, MAR, MAY, JUN, AUG, SEP, OCT, NOV, DEC
+from holidays.holiday_base import HolidayBase
+from holidays.groups import ChristianHolidays, InternationalHolidays
+
+
+class TurksAndCaicosIslands(HolidayBase, ChristianHolidays, InternationalHolidays):
+    """Turks and Caicos Islands holidays.
+    
+    References:
+        * https://en.wikipedia.org/wiki/Public_holidays_in_the_Turks_and_Caicos_Islands
+        * https://destinationtci.tc/turks-and-caicos-islands-public-holidays/
+        * https://www.timeanddate.com/holidays/turks-and-caicos-islands/
+    """
+
+    country = "TC"
+    default_language = "en_US"
+    supported_languages = ("en_US",)
+
+    def __init__(self, *args, **kwargs):
+        ChristianHolidays.__init__(self)
+        InternationalHolidays.__init__(self)
+        super().__init__(*args, **kwargs)
+
+    def _populate_public_holidays(self):
+        # New Year's Day
+        self._add_new_years_day(tr("New Year's Day"))
+
+        # Commonwealth Day (second Monday in March)
+        self._add_holiday_2nd_mon_of_mar(tr("Commonwealth Day"))
+
+        # Good Friday
+        self._add_good_friday(tr("Good Friday"))
+
+        # Easter Monday
+        self._add_easter_monday(tr("Easter Monday"))
+
+        # JAGS McCartney Day (last Monday in May)
+        self._add_holiday_last_mon_of_may(tr("JAGS McCartney Day"))
+
+        # King's Birthday (second Monday in June)
+        self._add_holiday_2nd_mon_of_jun(tr("King's Birthday"))
+
+        # Emancipation Day
+        self._add_holiday_aug_1(tr("Emancipation Day"))
+
+        # National Youth Day (last Friday in September)
+        self._add_holiday_last_fri_of_sep(tr("National Youth Day"))
+
+        # National Heritage Day (second Monday in October)
+        self._add_holiday_2nd_mon_of_oct(tr("National Heritage Day"))
+
+        # National Day of Thanksgiving (fourth Friday in November)
+        self._add_holiday_4th_fri_of_nov(tr("National Day of Thanksgiving"))
+
+        # Christmas Day
+        self._add_christmas_day(tr("Christmas Day"))
+
+        # Boxing Day
+        self._add_christmas_day_two(tr("Boxing Day"))
+
+
+class TC(TurksAndCaicosIslands):
+    pass
+
+
+class TCA(TurksAndCaicosIslands):
+    pass

--- a/holidays/locale/en_US/LC_MESSAGES/TC.po
+++ b/holidays/locale/en_US/LC_MESSAGES/TC.po
@@ -1,0 +1,76 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see AUTHORS.md file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/holidays
+#  License: MIT (see LICENSE file)
+#
+# Turks and Caicos Islands holidays en_US localization.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Holidays 0.22\n"
+"POT-Creation-Date: 2023-03-23 14:44+0200\n"
+"PO-Revision-Date: 2023-03-23 14:47+0200\n"
+"Last-Translator: Your Name <your.email@example.com>\n"
+"Language-Team: Holidays Localization Team\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Lingua 4.15.0\n"
+"X-Generator: Poedit 3.2.2\n"
+
+#. New Year's Day
+msgid "New Year's Day"
+msgstr "New Year's Day"
+
+#. Commonwealth Day
+msgid "Commonwealth Day"
+msgstr "Commonwealth Day"
+
+#. Good Friday
+msgid "Good Friday"
+msgstr "Good Friday"
+
+#. Easter Monday
+msgid "Easter Monday"
+msgstr "Easter Monday"
+
+#. JAGS McCartney Day
+msgid "JAGS McCartney Day"
+msgstr "JAGS McCartney Day"
+
+#. King's Birthday
+msgid "King's Birthday"
+msgstr "King's Birthday"
+
+#. Emancipation Day
+msgid "Emancipation Day"
+msgstr "Emancipation Day"
+
+#. National Youth Day
+msgid "National Youth Day"
+msgstr "National Youth Day"
+
+#. National Heritage Day
+msgid "National Heritage Day"
+msgstr "National Heritage Day"
+
+#. National Day of Thanksgiving
+msgid "National Day of Thanksgiving"
+msgstr "National Day of Thanksgiving"
+
+#. Christmas Day
+msgid "Christmas Day"
+msgstr "Christmas Day"
+
+#. Boxing Day
+msgid "Boxing Day"
+msgstr "Boxing Day"

--- a/holidays/registry.py
+++ b/holidays/registry.py
@@ -174,6 +174,7 @@ COUNTRIES: RegistryDict = {
     "tonga": ("Tonga", "TO", "TON"),
     "tunisia": ("Tunisia", "TN", "TUN"),
     "turkey": ("Turkey", "TR", "TUR"),
+    "turks_and_caicos_islands": ("Turks and Caicos Islands", "TC", "TCA"),
     "tuvalu": ("Tuvalu", "TV", "TUV"),
     "ukraine": ("Ukraine", "UA", "UKR"),
     "united_arab_emirates": ("UnitedArabEmirates", "AE", "ARE"),

--- a/tests/countries/test_turks_and_caicos_islands.py
+++ b/tests/countries/test_turks_and_caicos_islands.py
@@ -1,0 +1,75 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see AUTHORS.md file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/holidays
+#  License: MIT (see LICENSE file)
+
+from unittest import TestCase
+
+from holidays.countries.turks_and_caicos_islands import TurksAndCaicosIslands, TC, TCA
+from tests.common import CommonCountryTests
+
+
+class TestTC(CommonCountryTests, TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass(TurksAndCaicosIslands, years=range(2020, 2025))
+
+    def test_country_aliases(self):
+        self.assertAliases(TurksAndCaicosIslands, TC, TCA)
+
+    def test_2023(self):
+        self.assertHolidayDates(
+            TurksAndCaicosIslands(years=2023),
+            "2023-01-01",  # New Year's Day
+            "2023-03-13",  # Commonwealth Day (2nd Monday in March)
+            "2023-04-07",  # Good Friday
+            "2023-04-10",  # Easter Monday
+            "2023-05-29",  # JAGS McCartney Day (last Monday in May)
+            "2023-06-12",  # King's Birthday (2nd Monday in June)
+            "2023-08-01",  # Emancipation Day
+            "2023-09-29",  # National Youth Day (last Friday in September)
+            "2023-10-09",  # National Heritage Day (2nd Monday in October)
+            "2023-11-24",  # National Day of Thanksgiving (4th Friday in November)
+            "2023-12-25",  # Christmas Day
+            "2023-12-26",  # Boxing Day
+        )
+
+    def test_2025(self):
+        self.assertHolidayDates(
+            TurksAndCaicosIslands(years=2025),
+            "2025-01-01",  # New Year's Day
+            "2025-03-10",  # Commonwealth Day (2nd Monday in March)
+            "2025-04-18",  # Good Friday
+            "2025-04-21",  # Easter Monday
+            "2025-05-26",  # JAGS McCartney Day (last Monday in May)
+            "2025-06-09",  # King's Birthday (2nd Monday in June)
+            "2025-08-01",  # Emancipation Day
+            "2025-09-26",  # National Youth Day (last Friday in September)
+            "2025-10-13",  # National Heritage Day (2nd Monday in October)
+            "2025-11-28",  # National Day of Thanksgiving (4th Friday in November)
+            "2025-12-25",  # Christmas Day
+            "2025-12-26",  # Boxing Day
+        )
+
+    def test_l10n_default(self):
+        self.assertLocalizedHolidays(
+            ("2025-01-01", "New Year's Day"),
+            ("2025-03-10", "Commonwealth Day"),
+            ("2025-04-18", "Good Friday"),
+            ("2025-04-21", "Easter Monday"),
+            ("2025-05-26", "JAGS McCartney Day"),
+            ("2025-06-09", "King's Birthday"),
+            ("2025-08-01", "Emancipation Day"),
+            ("2025-09-26", "National Youth Day"),
+            ("2025-10-13", "National Heritage Day"),
+            ("2025-11-28", "National Day of Thanksgiving"),
+            ("2025-12-25", "Christmas Day"),
+            ("2025-12-26", "Boxing Day"),
+        )


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

This PR adds official public holiday support for the **Turks and Caicos Islands (TC)** to the `holidays` package.

**Issue:** Fixes #2435

Holidays included are based on:
- https://en.wikipedia.org/wiki/Public_holidays_in_the_Turks_and_Caicos_Islands
- https://destinationtci.tc/turks-and-caicos-islands-public-holidays/
- https://www.timeanddate.com/holidays/turks-and-caicos-islands/

The implementation covers fixed holidays and movable holidays like Easter-related dates and the King's Birthday.

## Type of change

- [x] New country/market holidays support (thank you!)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
