### PR TITLE
Update Singapore holidays: 2025 Polling Day on May 3rd

### DIFF
--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -307,7 +307,9 @@ class SingaporeStaticHolidays:
 
     References:
         * <https://www.mom.gov.sg/newsroom/press-releases/2015/sg50-public-holiday-on-7-august-2015>
-        * <https://www.straitstimes.com/singapore/politics/singapore-presidential-election-2023-polling-day-on-sept-1-nomination-day-on-aug-22>
+        * <https://www.mom.gov.sg/newsroom/press-releases/2020/0624-public-holiday-on-polling-day---10-july-2020>
+        * <https://www.mom.gov.sg/newsroom/press-releases/2023/0822-public-holiday-on-polling-day---1-sep-2023>
+        * <https://www.mom.gov.sg/newsroom/press-releases/2025/0415-public-holiday-on-polling-day_3-may-2025>
     """
 
     # Polling Day.
@@ -324,6 +326,7 @@ class SingaporeStaticHolidays:
         ),
         2020: (JUL, 10, polling_day_name),
         2023: (SEP, 1, polling_day_name),
+        2025: (MAY, 3, polling_day_name),
     }
 
     special_public_holidays_observed = {

--- a/snapshots/countries/SG_COMMON.json
+++ b/snapshots/countries/SG_COMMON.json
@@ -953,6 +953,7 @@
     "2025-03-31": "Eid al-Fitr",
     "2025-04-18": "Good Friday",
     "2025-05-01": "Labor Day",
+    "2025-05-03": "Polling Day",
     "2025-05-12": "Vesak Day",
     "2025-06-07": "Eid al-Adha",
     "2025-08-09": "National Day",

--- a/tests/countries/test_singapore.py
+++ b/tests/countries/test_singapore.py
@@ -186,6 +186,7 @@ class TestSingapore(CommonCountryTests, TestCase):
             ("2025-03-31", "Hari Raya Puasa"),
             ("2025-04-18", "Good Friday"),
             ("2025-05-01", "Labour Day"),
+            ("2025-05-03", "Polling Day"),
             ("2025-05-12", "Vesak Day"),
             ("2025-06-07", "Hari Raya Haji"),
             ("2025-08-09", "National Day"),
@@ -197,7 +198,16 @@ class TestSingapore(CommonCountryTests, TestCase):
         self.assertNoNonObservedHoliday("2023-01-02")
 
     def test_special_holidays(self):
-        self.assertHoliday("2015-08-07")
+        self.assertHoliday(
+            "2001-11-03",
+            "2006-05-06",
+            "2011-05-07",
+            "2015-08-07",
+            "2015-09-11",
+            "2020-07-10",
+            "2023-09-01",
+            "2025-05-03",
+        )
 
     def test_l10n_default(self):
         self.assertLocalizedHolidays(


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

- Add Singapore's 2025 polling day.
- Update special holidays sources from 2020 onwards to use the https://mom.gov.sg source.
- Add every special holiday entry to `test_special_holiday` .

Resolves #2486.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
