### PR TITLE
Update Argentina holidays: add 2018 G20 Leaders' Summit for Buenos Aires

### DIFF
--- a/holidays/countries/argentina.py
+++ b/holidays/countries/argentina.py
@@ -828,6 +828,9 @@ class ArgentinaStaticHolidays:
         * [Release P51020 (2021)](https://bcra.gob.ar/Pdfs/comytexord/P51020.pdf)
         * [Release P51155 (2024)](https://bcra.gob.ar/Pdfs/comytexord/P51155.pdf)
 
+    Special Subdivision-level Holidays References:
+        * [2018 G20 Leader Summit Special Holidays for Buenos Aires](https://web.archive.org/web/20220305033755/https://www.perfil.com/noticias/sociedad/30-de-noviembre-feriado-ciudad-de-buenos-aires-cumbre-g20.phtml)
+
     Special Bridge Holidays are given upto 3 days a year as long as it's declared
     50 days before calendar year's end.
     There's no Bridge Holidays declared in 2017.
@@ -868,6 +871,9 @@ class ArgentinaStaticHolidays:
 
     # National Census Day 2010.
     national_census_2010 = tr("Censo Nacional 2010")
+
+    # G20 Leaders' Summit.
+    g20_leaders_summit_holiday = tr("Cumbre de Líderes del Grupo de los 20 (G20)")
 
     # National Census Day 2022.
     national_census_2022 = tr("Censo Nacional 2022")
@@ -984,4 +990,8 @@ class ArgentinaStaticHolidays:
             (DEC, 24, bank_holiday),
             (DEC, 31, bank_holiday),
         ),
+    }
+
+    special_b_public_holidays = {
+        2018: (NOV, 30, g20_leaders_summit_holiday),
     }

--- a/holidays/locale/en_US/LC_MESSAGES/AR.po
+++ b/holidays/locale/en_US/LC_MESSAGES/AR.po
@@ -14,18 +14,17 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.70\n"
+"Project-Id-Version: Holidays 0.73\n"
 "POT-Creation-Date: 2023-03-02 00:39+0700\n"
-"PO-Revision-Date: 2025-03-19 13:55+0200\n"
-"Last-Translator: ~Jhellico <jhellico@gmail.com>\n"
+"PO-Revision-Date: 2025-05-06 10:34+0700\n"
+"Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: pygettext.py 1.5\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.6\n"
 "X-Source-Language: es\n"
 
 #. %s (observed).
@@ -367,3 +366,7 @@ msgstr "FIFA World Cup 2022 Victory Day"
 #. Bank Holiday.
 msgid "Asueto bancario"
 msgstr "Bank Holiday"
+
+#. G20 Leaders' Summit.
+msgid "Cumbre de Líderes del Grupo de los 20 (G20)"
+msgstr "G20 Leaders' Summit"

--- a/holidays/locale/es/LC_MESSAGES/AR.po
+++ b/holidays/locale/es/LC_MESSAGES/AR.po
@@ -14,18 +14,17 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.70\n"
+"Project-Id-Version: Holidays 0.73\n"
 "POT-Creation-Date: 2023-03-02 00:39+0700\n"
-"PO-Revision-Date: 2025-03-19 13:53+0200\n"
-"Last-Translator: ~Jhellico <jhellico@gmail.com>\n"
+"PO-Revision-Date: 2025-05-06 10:34+0700\n"
+"Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Lingua 4.15.0\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.6\n"
 "X-Source-Language: es\n"
 
 #. %s (observed).
@@ -366,4 +365,8 @@ msgstr ""
 
 #. Bank Holiday.
 msgid "Asueto bancario"
+msgstr ""
+
+#. G20 Leaders' Summit.
+msgid "Cumbre de Líderes del Grupo de los 20 (G20)"
 msgstr ""

--- a/holidays/locale/uk/LC_MESSAGES/AR.po
+++ b/holidays/locale/uk/LC_MESSAGES/AR.po
@@ -14,18 +14,17 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.70\n"
+"Project-Id-Version: Holidays 0.73\n"
 "POT-Creation-Date: 2023-03-02 00:39+0700\n"
-"PO-Revision-Date: 2025-03-19 13:59+0200\n"
-"Last-Translator: ~Jhellico <jhellico@gmail.com>\n"
+"PO-Revision-Date: 2025-05-06 10:34+0700\n"
+"Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "Generated-By: Lingua 4.15.0\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.6\n"
 "X-Source-Language: es\n"
 
 #. %s (observed).
@@ -367,3 +366,7 @@ msgstr "День перемоги збірної Аргентини на Чем�
 #. Bank Holiday.
 msgid "Asueto bancario"
 msgstr "Банківський вихідний"
+
+#. G20 Leaders' Summit.
+msgid "Cumbre de Líderes del Grupo de los 20 (G20)"
+msgstr "Саміт лідерів Групи двадцяти (G20)"

--- a/snapshots/countries/AR_B.json
+++ b/snapshots/countries/AR_B.json
@@ -1050,6 +1050,7 @@
     "2018-10-15": "Respect for Cultural Diversity Day",
     "2018-11-06": "Bankers' Day",
     "2018-11-19": "National Sovereignty Day",
+    "2018-11-30": "G20 Leaders' Summit",
     "2018-12-08": "Immaculate Conception",
     "2018-12-24": "Bridge Public Holiday",
     "2018-12-25": "Christmas Day",

--- a/tests/countries/test_argentina.py
+++ b/tests/countries/test_argentina.py
@@ -99,6 +99,10 @@ class TestArgentina(CommonCountryTests, TestCase):
             "2024-12-31",
         )
 
+    def test_special_subdiv_holidays(self):
+        # Buenos Aires.
+        self.assertHoliday(self.subdiv_holidays["B"], "2018-11-30")
+
     def test_new_years_day(self):
         self.assertHolidayName("Año Nuevo", (f"{year}-01-01" for year in range(1957, 2050)))
 


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Adds November 30, 2018, as a one-off public holiday in Buenos Aires for the G20 Leaders' Summit.

Resolves #2528.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [ ] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
