### PR TITLE
Improve Fête de la libération test coverage for Togo

### DIFF
--- a/tests/countries/test_togo.py
+++ b/tests/countries/test_togo.py
@@ -38,7 +38,7 @@ class TestTogo(CommonCountryTests, TestCase):
     def test_liberation_day(self):
         name = "Fête de la libération nationale"
         self.assertHolidayName(name, (f"{year}-01-13" for year in range(1967, 2014)))
-        self.assertNoHolidayName(name, range(2014, 2050))
+        self.assertNoHolidayName(name, range(1961, 1967), range(2014, 2050))
 
     def test_easter_monday(self):
         name = "Lundi de Pâques"


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Add a missing `range(1961, 1967)` to `assertNoHolidayName()` for **Fête de la libération nationale** as discovered during a code review discussion for #2609 .

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
