### PR TITLE
Update Svalbard and Jan Mayen holidays: remove l10n overrides

### DIFF
--- a/holidays/countries/svalbard_and_jan_mayen.py
+++ b/holidays/countries/svalbard_and_jan_mayen.py
@@ -25,10 +25,8 @@ class HolidaysSJ(Norway):
 
     country = "SJ"
     parent_entity = Norway
-    default_language = "no"
     subdivisions = ()  # Override Norway subdivisions.
     subdivisions_aliases = {}  # Override Norway subdivisions aliases.
-    supported_languages = ("en_US", "no", "th", "uk")
 
     def _populate_public_holidays(self) -> None:
         self.subdiv = "21"


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

[As raised by](https://github.com/vacanza/holidays/pull/2642#discussion_r2154215813) @coderabbitai for PR #2642.
> **You redefine `supported_languages`; risk of future drift.**
> Parent entities already maintains its own tuple.  If a new language is later added upstream, `HolidaysXX` will silently miss it.
> Keeps things DRY.  

Since Svalbard and Jan Mayen use the same `default_language` as Norway, there's no need to keep a separate list unlike the Åland Islands (which I'm getting back to finish implementing that l10n feature soon)

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
