### PR TITLE
Show test coverage details by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,7 @@ make pre-commit
 make test
 ```
 
-If you want to retrieve uncovered lines too:
-
-``` shell
-make coverage
-```
+It'll retrieve uncovered lines too
 
 You can run specific tests using the `pytest` command:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ make pre-commit
 make test
 ```
 
-It'll retrieve uncovered lines too
+It'll retrieve uncovered lines too.
 
 You can run specific tests using the `pytest` command:
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 help:
 	@echo "Usage: make <target>"
 	@echo "    check         run pre-commit and tests"
-	@echo "    coverage      identify code not covered with tests"
 	@echo "    doc           run documentation build process"
 	@echo "    help          show summary of available commands"
 	@echo "    l10n          update .pot and .po files"
@@ -22,9 +21,6 @@ clean:
 		find . -type f -name "*.$$ext" -delete; \
 	done
 	@rm -rf .mypy_cache .pytest_cache dist .tox
-
-coverage:
-	pytest --cov=. --cov-config=pyproject.toml --cov-report term-missing --dist loadscope --no-cov-on-fail --numprocesses auto
 
 doc:
 	mkdocs build
@@ -64,7 +60,7 @@ snapshot:
 
 test:
 	scripts/l10n/generate_mo_files.py
-	pytest --cov=. --cov-config=pyproject.toml --cov-report term --cov-report xml --durations 10 --durations-min=0.75 --dist loadscope --no-cov-on-fail --numprocesses auto
+	pytest --cov=. --cov-config=pyproject.toml --cov-report term-missing --cov-report xml --durations 10 --durations-min=0.75 --dist loadscope --no-cov-on-fail --numprocesses auto
 
 tox:
 	tox --parallel auto

--- a/make.cmd
+++ b/make.cmd
@@ -25,10 +25,6 @@ GoTo :Help
     RD /S /Q dist
     Exit /B
 
-:Coverage
-    pytest --cov=. --cov-config=pyproject.toml --cov-report term-missing --dist loadscope --no-cov-on-fail --numprocesses auto
-    Exit /B
-
 :Doc
     mkdocs build
     Exit /B
@@ -36,7 +32,6 @@ GoTo :Help
 :Help
     Echo Usage: make ^<Target^>
     Echo     check         run pre-commit and tests
-    Echo     coverage      identify code not covered with tests
     Echo     doc           run documentation build process
     Echo     help          show summary of available commands
     Echo     l10n          update .pot and .po files
@@ -88,7 +83,7 @@ GoTo :Help
 
 :Test
     python scripts\l10n\generate_mo_files.py
-    pytest --cov=. --cov-config=pyproject.toml --cov-report term --cov-report xml --durations 10 --durations-min=0.75 --dist loadscope --no-cov-on-fail --numprocesses auto
+    pytest --cov=. --cov-config=pyproject.toml --cov-report term-missing --cov-report xml --durations 10 --durations-min=0.75 --dist loadscope --no-cov-on-fail --numprocesses auto
     Exit /B
 
 :Tox


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Retire `make coverage`, extend `make test` to show uncovered lines by default.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
