### PR TITLE
Refactor US holidays: consolidate duplicate `self._year` triggers

### DIFF
--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -994,7 +994,6 @@ class UnitedStates(ObservedHolidayBase, ChristianHolidays, InternationalHolidays
             # Lincoln's Birthday.
             self._add_observed(self._add_holiday_feb_12(tr("Lincoln's Birthday")))
 
-        if self._year >= 1971:
             # Presidents Day.
             self._add_holiday_3rd_mon_of_feb(tr("Presidents Day"))
 
@@ -1176,7 +1175,6 @@ class UnitedStates(ObservedHolidayBase, ChristianHolidays, InternationalHolidays
             # Christmas Eve.
             self._add_christmas_eve_holiday()
 
-        if self._year >= 1981:
             # Day After Christmas.
             self._add_christmas_day_two(tr("Day After Christmas"))
 
@@ -1217,7 +1215,6 @@ class UnitedStates(ObservedHolidayBase, ChristianHolidays, InternationalHolidays
             # George Washington Day.
             self._add_holiday_3rd_mon_of_feb(tr("George Washington Day"))
 
-        if self._year >= 1971:
             self._add_holiday_2nd_mon_of_oct(
                 # Indigenous Peoples' Day.
                 tr("Indigenous Peoples' Day")


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Consolidate duplicate `self._years` triggers for the United States holidays I've spotted while reviewing PR #2722 .

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've successfully run `make check`, all checks and tests are green

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md
[docs]: https://github.com/vacanza/holidays/tree/dev/docs/source
