### PR TITLE
Input handling improvements for `get_nth_working_day`

### DIFF
--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -1129,14 +1129,14 @@ class HolidayBase(dict[date, str]):
         Returns:
             The calculated working day after shifting by n working days.
         """
+        direction = +1 if n >= 0 else -1
         dt = self.__keytransform__(key)
         # Special case: n is 0 return today if working day, else get next working day.
         if n == 0:
             while not self.is_working_day(dt):
-                dt = _timedelta(dt, 1)
+                dt = _timedelta(dt, direction)
             return dt
         # General case.
-        direction = +1 if n >= 0 else -1
         for _ in range(abs(n)):
             dt = _timedelta(dt, direction)
             while not self.is_working_day(dt):

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -1116,6 +1116,7 @@ class HolidayBase(dict[date, str]):
         """Find the n-th working day from a given date.
 
         Moves forward if n is positive, or backward if n is negative.
+        If n is 0, will return today if a working day, else get next working day.
 
         Args:
             key:
@@ -1128,8 +1129,14 @@ class HolidayBase(dict[date, str]):
         Returns:
             The calculated working day after shifting by n working days.
         """
-        direction = +1 if n > 0 else -1
         dt = self.__keytransform__(key)
+        # Special case: n is 0 return today if working day, else get next working day.
+        if n == 0:
+            while not self.is_working_day(dt):
+                dt = _timedelta(dt, 1)
+            return dt
+        # General case.
+        direction = +1 if n >= 0 else -1
         for _ in range(abs(n)):
             dt = _timedelta(dt, direction)
             while not self.is_working_day(dt):

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -1131,12 +1131,9 @@ class HolidayBase(dict[date, str]):
         """
         direction = +1 if n >= 0 else -1
         dt = self.__keytransform__(key)
-        if n == 0:
-            while not self.is_working_day(dt):
+        for _ in range(abs(n) if n != 0 else 1):
+            if n != 0:
                 dt = _timedelta(dt, direction)
-            return dt
-        for _ in range(abs(n)):
-            dt = _timedelta(dt, direction)
             while not self.is_working_day(dt):
                 dt = _timedelta(dt, direction)
         return dt

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -1116,7 +1116,7 @@ class HolidayBase(dict[date, str]):
         """Find the n-th working day from a given date.
 
         Moves forward if n is positive, or backward if n is negative.
-        If n is 0, will return today if a working day, else get next working day.
+        If n is 0, returns the given date if it is a working day; otherwise the next working day.
 
         Args:
             key:
@@ -1131,8 +1131,8 @@ class HolidayBase(dict[date, str]):
         """
         direction = +1 if n >= 0 else -1
         dt = self.__keytransform__(key)
-        for _ in range(abs(n) if n != 0 else 1):
-            if n != 0:
+        for _ in range(abs(n) or 1):
+            if n:
                 dt = _timedelta(dt, direction)
             while not self.is_working_day(dt):
                 dt = _timedelta(dt, direction)

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -1131,12 +1131,10 @@ class HolidayBase(dict[date, str]):
         """
         direction = +1 if n >= 0 else -1
         dt = self.__keytransform__(key)
-        # Special case: n is 0 return today if working day, else get next working day.
         if n == 0:
             while not self.is_working_day(dt):
                 dt = _timedelta(dt, direction)
             return dt
-        # General case.
         for _ in range(abs(n)):
             dt = _timedelta(dt, direction)
             while not self.is_working_day(dt):

--- a/tests/test_holiday_base.py
+++ b/tests/test_holiday_base.py
@@ -1262,6 +1262,10 @@ class TestWorkdays(unittest.TestCase):
         self.assertEqual(self.hb.get_nth_working_day("2024-05-10", -7), date(2024, 4, 29))
         self.assertEqual(self.hb.get_nth_working_day("2024-05-10", -5), date(2024, 5, 3))
 
+        self.assertEqual(self.hb.get_nth_working_day("2024-07-27", 0), date(2024, 7, 29))
+        self.assertEqual(self.hb.get_nth_working_day("2024-07-27", 1), date(2024, 7, 29))
+        self.assertEqual(self.hb.get_nth_working_day("2024-07-29", 0), date(2024, 7, 29))
+
     def test_get_working_days_count(self):
         self.assertEqual(self.hb.get_working_days_count("2024-01-03", "2024-01-23"), 15)
         self.assertEqual(self.hb.get_working_days_count("2024-01-23", "2024-01-03"), 15)


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

If `n` input for `get_nth_working_day` is 0 and the current date isn't a working day, this will now returns the next working day instead.

Resolves #2758 

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
