### PR TITLE
Update Chile holidays: abolition of Dec 31 bank holiday

### DIFF
--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -58,7 +58,7 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         * [Law 19.559 (restore Dec 31)](https://web.archive.org/web/20241227195811/https://www.bcn.cl/leychile/navegar?idNorma=97758&idVersion=1998-04-16)
         * [Law 21.521 (eliminate Dec 31 again, after the CMF publishes a specific regulation)](https://web.archive.org/web/20240214154900/https://www.bcn.cl/leychile/navegar?idNorma=1187323&idVersion=2023-02-03)
         * [Norma de Carácter General N° 543 de la CMF](https://www.cmfchile.cl/normativa/ncg_543_2025.pdf)
-+       * [Resolución Exenta N° 7.671 (CMF, 2025-08-01)](https://www.cmfchile.cl/sitio/aplic/serdoc/ver_sgd.php?s567=ba5ad42feea3531a678a9db5253a9477VFdwQmVVNVVRVFJOUkZWNlRucEpORTVCUFQwPQ==&secuencia=-1&t=1754086087)
+        * [Resolución Exenta N° 7.671 (CMF, 2025-08-01)](https://www.cmfchile.cl/sitio/aplic/serdoc/ver_sgd.php?s567=ba5ad42feea3531a678a9db5253a9477VFdwQmVVNVVRVFJOUkZWNlRucEpORTVCUFQwPQ==&secuencia=-1&t=1754086087)
     """
 
     country = "CL"

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -57,7 +57,7 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         * [Law 19.528 (eliminate Dec 31)](https://web.archive.org/web/20241227191452/https://www.bcn.cl/leychile/navegar?idNorma=76630&idVersion=1997-11-04)
         * [Law 19.559 (restore Dec 31)](https://web.archive.org/web/20241227195811/https://www.bcn.cl/leychile/navegar?idNorma=97758&idVersion=1998-04-16)
         * [Law 21.521 (eliminate Dec 31 again, after the CMF publishes a specific regulation)](https://web.archive.org/web/20240214154900/https://www.bcn.cl/leychile/navegar?idNorma=1187323&idVersion=2023-02-03)
-        * [Normativa de Carácter General 543 de la Comisión para el Mercado Financieron (the regulation required by the law 21.521 to make the Dec 31 elimination come into vigour)](https://www.cmfchile.cl/normativa/ncg_543_2025.pdf)
+        * [Normativa de Carácter General 543 de la CMF](https://www.cmfchile.cl/normativa/ncg_543_2025.pdf)
     """
 
     country = "CL"

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -57,7 +57,7 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         * [Law 19.528 (eliminate Dec 31)](https://web.archive.org/web/20241227191452/https://www.bcn.cl/leychile/navegar?idNorma=76630&idVersion=1997-11-04)
         * [Law 19.559 (restore Dec 31)](https://web.archive.org/web/20241227195811/https://www.bcn.cl/leychile/navegar?idNorma=97758&idVersion=1998-04-16)
         * [Law 21.521 (eliminate Dec 31 again, after the CMF publishes a specific regulation)](https://web.archive.org/web/20240214154900/https://www.bcn.cl/leychile/navegar?idNorma=1187323&idVersion=2023-02-03)
-        * [Normativa de Carácter General 543 de la CMF](https://www.cmfchile.cl/normativa/ncg_543_2025.pdf)
+        * [Norma de Carácter General N° 543 de la CMF](https://www.cmfchile.cl/normativa/ncg_543_2025.pdf)
     """
 
     country = "CL"

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -57,8 +57,8 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         * [Law 19.528 (eliminate Dec 31)](https://web.archive.org/web/20241227191452/https://www.bcn.cl/leychile/navegar?idNorma=76630&idVersion=1997-11-04)
         * [Law 19.559 (restore Dec 31)](https://web.archive.org/web/20241227195811/https://www.bcn.cl/leychile/navegar?idNorma=97758&idVersion=1998-04-16)
         * [Law 21.521 (eliminate Dec 31 again, after the CMF publishes a specific regulation)](https://web.archive.org/web/20240214154900/https://www.bcn.cl/leychile/navegar?idNorma=1187323&idVersion=2023-02-03)
-        * [Norma de Carácter General N° 543 de la CMF](https://www.cmfchile.cl/normativa/ncg_543_2025.pdf)
-        * [Resolución Exenta N° 7.671 (CMF, 2025-08-01)](https://www.cmfchile.cl/sitio/aplic/serdoc/ver_sgd.php?s567=ba5ad42feea3531a678a9db5253a9477VFdwQmVVNVVRVFJOUkZWNlRucEpORTVCUFQwPQ==&secuencia=-1&t=1754086087)
+        * [Norma de Carácter General N° 543 de la CMF](https://web.archive.org/web/20250811111649/https://www.cmfchile.cl/normativa/ncg_543_2025.pdf)
+        * [Resolución Exenta N° 7.671 (CMF, 2025-08-01)](https://web.archive.org/web/20250811123908/https://www.cmfchile.cl/sitio/aplic/serdoc/ver_sgd.php?s567=ba5ad42feea3531a678a9db5253a9477VFdwQmVVNVVRVFJOUkZWNlRucEpORTVCUFQwPQ==&secuencia=-1&t=1754086087)
     """
 
     country = "CL"

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -58,6 +58,7 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         * [Law 19.559 (restore Dec 31)](https://web.archive.org/web/20241227195811/https://www.bcn.cl/leychile/navegar?idNorma=97758&idVersion=1998-04-16)
         * [Law 21.521 (eliminate Dec 31 again, after the CMF publishes a specific regulation)](https://web.archive.org/web/20240214154900/https://www.bcn.cl/leychile/navegar?idNorma=1187323&idVersion=2023-02-03)
         * [Norma de Carácter General N° 543 de la CMF](https://www.cmfchile.cl/normativa/ncg_543_2025.pdf)
++       * [Resolución Exenta N° 7.671 (CMF, 2025-08-01)](https://www.cmfchile.cl/sitio/aplic/serdoc/ver_sgd.php?s567=ba5ad42feea3531a678a9db5253a9477VFdwQmVVNVVRVFJOUkZWNlRucEpORTVCUFQwPQ==&secuencia=-1&t=1754086087)
     """
 
     country = "CL"

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -31,7 +31,8 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
 
     References:
         * <https://web.archive.org/web/20250718012109/https://www.feriados.cl/>
-        * [Excellent history of Chile holidays](https://web.archive.org/web/20250712031422/https://www.feriadoschilenos.cl/)
+        * Excellent history of Chile holidays
+          URL: https://web.archive.org/web/20250712031422/https://www.feriadoschilenos.cl/
         * <https://es.wikipedia.org/wiki/Anexo:Días_feriados_en_Chile>
         * Law 2.977 (established official Chile holidays in its current form)
         * Law 20.983 (Day after New Year's Day, if it's a Sunday)

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -31,8 +31,7 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
 
     References:
         * <https://web.archive.org/web/20250718012109/https://www.feriados.cl/>
-        * Excellent history of Chile holidays
-          URL: https://web.archive.org/web/20250712031422/https://www.feriadoschilenos.cl/
+        * [Excellent history of Chile holidays](https://web.archive.org/web/20250712031422/https://www.feriadoschilenos.cl/)
         * <https://es.wikipedia.org/wiki/Anexo:Días_feriados_en_Chile>
         * Law 2.977 (established official Chile holidays in its current form)
         * Law 20.983 (Day after New Year's Day, if it's a Sunday)

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -239,7 +239,7 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         if 1957 <= self._year <= 1975:
             self._add_holiday_jun_30(name)
 
-        if (1956 <= self._year <= 2024) and (self._year != 1997):
+        if 1956 <= self._year <= 2024 and self._year != 1997:
             self._add_holiday_dec_31(name)
 
     @property

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -56,6 +56,8 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         * [Decree-law 1.171 (eliminate Jun 30)](https://web.archive.org/web/20241227191010/https://www.bcn.cl/leychile/navegar?idNorma=6507&idVersion=1975-09-05)
         * [Law 19.528 (eliminate Dec 31)](https://web.archive.org/web/20241227191452/https://www.bcn.cl/leychile/navegar?idNorma=76630&idVersion=1997-11-04)
         * [Law 19.559 (restore Dec 31)](https://web.archive.org/web/20241227195811/https://www.bcn.cl/leychile/navegar?idNorma=97758&idVersion=1998-04-16)
+        * [Law 21.521 (eliminate Dec 31 again, after the CMF publishes a specific regulation)](https://web.archive.org/web/20240214154900/https://www.bcn.cl/leychile/navegar?idNorma=1187323&idVersion=2023-02-03)
+        * [Normativa de Carácter General 543 de la Comisión para el Mercado Financieron (the regulation required by the law 21.521 to make the Dec 31 elimination come into vigour)](https://www.cmfchile.cl/normativa/ncg_543_2025.pdf)
     """
 
     country = "CL"

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -30,8 +30,8 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
     """Chile holidays.
 
     References:
-        * <https://web.archive.org/web/20250418020620/https://www.feriados.cl/>
-        * [Excellent history of Chile holidays](https://web.archive.org/web/20250124223839/https://www.feriadoschilenos.cl/)
+        * <https://web.archive.org/web/20250718012109/https://www.feriados.cl/>
+        * [Excellent history of Chile holidays](https://web.archive.org/web/20250712031422/https://www.feriadoschilenos.cl/)
         * <https://es.wikipedia.org/wiki/Anexo:Días_feriados_en_Chile>
         * Law 2.977 (established official Chile holidays in its current form)
         * Law 20.983 (Day after New Year's Day, if it's a Sunday)
@@ -237,7 +237,7 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         if 1957 <= self._year <= 1975:
             self._add_holiday_jun_30(name)
 
-        if self._year >= 1956 and self._year != 1997:
+        if (1956 <= self._year <= 2024) and (self._year != 1997):
             self._add_holiday_dec_31(name)
 
     @property

--- a/tests/countries/test_chile.py
+++ b/tests/countries/test_chile.py
@@ -279,12 +279,13 @@ class TestChile(CommonCountryTests, TestCase):
         holidays = Chile(categories=BANK, years=range(1915, 2050))
         self.assertHolidayName(name, holidays, (f"{year}-06-30" for year in range(1957, 1976)))
         self.assertHolidayName(name, holidays, (f"{year}-12-31" for year in range(1956, 1997)))
-        self.assertHolidayName(name, holidays, (f"{year}-12-31" for year in range(1998, 2050)))
+        self.assertHolidayName(name, holidays, (f"{year}-12-31" for year in range(1998, 2025)))
         self.assertNoHoliday(holidays, (f"{year}-06-30" for year in range(1915, 1957)))
         self.assertNoHoliday(holidays, (f"{year}-06-30" for year in range(1976, 2050)))
         self.assertNoHoliday(
             holidays, (f"{year}-12-31" for year in range(1915, 1956)), "1997-12-31"
         )
+        self.assertNoHoliday(holidays, (f"{year}-12-31" for year in range(2025, 2050)))
         self.assertNoHolidayName(name, holidays, range(1915, 1956))
 
     def test_2019(self):


### PR DESCRIPTION
## Proposed change

The abolition of December 31st banking holiday was written into law on January 2023, and this came into force on 1 August 2025, with the publication of the relevant resolution by the CMF ("Comisión para el Mercado Financiero"). I've updated the 31 December rule to ensure the bank holiday is only valid until year 2024 and no further.

I've also updated both WayBack Machine references to the latest archival URLs.

This is a simple modification to keep the Chilean ruleset up-to-date.

## Type of change

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [ ] I've run `make check` locally; all checks and tests passed.
