### PR TITLE
Update Canada holidays: add National Day for Truth and Reconciliation in MB

### DIFF
--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -279,8 +279,10 @@ class Canada(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         self._add_victoria_day()
 
         if self._year >= 2024:
-            # National Day for Truth and Reconciliation.
-            self._add_holiday_sep_30(tr("National Day for Truth and Reconciliation"))
+            self._add_observed(
+                # National Day for Truth and Reconciliation.
+                self._add_holiday_sep_30(tr("National Day for Truth and Reconciliation"))
+            )
 
         self._add_thanksgiving_day()
 

--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -46,6 +46,7 @@ class Canada(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         * <https://web.archive.org/web/20250428154427/https://recherche-collection-search.bac-lac.gc.ca/eng/home/record?idnumber=9326&app=diawlmking&ecopy=80003QJW>
         * <https://web.archive.org/web/20240915001506/https://www.britannica.com/topic/Victoria-Day>
         * [NT National Aboriginal Day](https://web.archive.org/web/20160623071755/http://www.daair.gov.nt.ca/_live/pages/wpPages/National_Aboriginal_Day.aspx)
+        * [MB National Day for Truth and Reconciliation](https://web.archive.org/web/20240714223654/https://web2.gov.mb.ca/bills/43-1/b004e.php)
     """
 
     country = "CA"
@@ -276,6 +277,10 @@ class Canada(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
             self._add_holiday_3rd_mon_of_feb(tr("Louis Riel Day"))
 
         self._add_victoria_day()
+
+        if self._year >= 2024:
+            # National Day for Truth and Reconciliation.
+            self._add_holiday_sep_30(tr("National Day for Truth and Reconciliation"))
 
         self._add_thanksgiving_day()
 

--- a/tests/countries/test_canada.py
+++ b/tests/countries/test_canada.py
@@ -288,6 +288,13 @@ class TestCanada(CommonCountryTests, TestCase):
                 self.assertNoHolidayName(name, holidays)
             self.assertNoNonObservedHoliday(self.subdiv_holidays_non_observed[subdiv], dts)
 
+        self.assertHolidayName(
+            name_observed, self.subdiv_holidays["MB"], "2028-10-02", "2029-10-01"
+        )
+        self.assertNoNonObservedHoliday(
+            self.subdiv_holidays_non_observed["MB"], "2028-10-02", "2029-10-01"
+        )
+
         ab_optional_holidays = self.subdiv_optional_holidays["AB"]
         self.assertHolidayName(
             name, ab_optional_holidays, (f"{year}-09-30" for year in range(2021, 2050))

--- a/tests/countries/test_canada.py
+++ b/tests/countries/test_canada.py
@@ -270,29 +270,29 @@ class TestCanada(CommonCountryTests, TestCase):
         self.assertHolidayName(name_observed, self.government_holidays, dts)
         self.assertNoNonObservedHoliday(self.government_holidays_non_observed, dts)
 
-        start_years = {
-            "AB": 2021,
+        subdiv_start_years = {
             "BC": 2023,
+            "MB": 2024,
             "NT": 2022,
             "NU": 2022,
             "PE": 2022,
             "YT": 2023,
         }
         for subdiv, holidays in self.subdiv_holidays.items():
-            if subdiv in {"BC", "NT", "NU", "PE", "YT"}:
+            if start_year := subdiv_start_years.get(subdiv):
                 self.assertHolidayName(
-                    name, holidays, (f"{year}-09-30" for year in range(start_years[subdiv], 2050))
+                    name, holidays, (f"{year}-09-30" for year in range(start_year, 2050))
                 )
-                self.assertNoHolidayName(name, holidays, range(1867, start_years[subdiv]))
+                self.assertNoHolidayName(name, holidays, range(1867, start_year))
             else:
                 self.assertNoHolidayName(name, holidays)
             self.assertNoNonObservedHoliday(self.subdiv_holidays_non_observed[subdiv], dts)
 
+        ab_optional_holidays = self.subdiv_optional_holidays["AB"]
         self.assertHolidayName(
-            name,
-            self.subdiv_optional_holidays["AB"],
-            (f"{year}-09-30" for year in range(2021, 2050)),
+            name, ab_optional_holidays, (f"{year}-09-30" for year in range(2021, 2050))
         )
+        self.assertNoHolidayName(name, ab_optional_holidays, range(1867, 2021))
 
     def test_thanksgiving_day(self):
         name_1921 = "Armistice Day"


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Update Canada holidays: add National Day for Truth and Reconciliation in Manitoba (since 2024).

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
