### PR TITLE
Update Chinese Lunisolar calendar: extend Winter Solstice support

### DIFF
--- a/holidays/calendars/chinese.py
+++ b/holidays/calendars/chinese.py
@@ -14,7 +14,7 @@ from datetime import date
 from typing import Optional
 
 from holidays.calendars.custom import _CustomCalendar
-from holidays.calendars.gregorian import JAN, FEB, MAR, APR, MAY, JUN, SEP, OCT, NOV
+from holidays.calendars.gregorian import JAN, FEB, MAR, APR, MAY, JUN, SEP, OCT, NOV, DEC
 
 CHINESE_CALENDAR = "CHINESE_CALENDAR"
 KOREAN_CALENDAR = "KOREAN_CALENDAR"
@@ -1358,6 +1358,46 @@ class _ChineseLunisolar:
 
     def mid_autumn_date(self, year: int, calendar=None) -> tuple[Optional[date], bool]:
         return self._get_holiday(MID_AUTUMN, year, calendar)
+
+    def winter_solstice_date(self, year: int, calendar=None) -> tuple[Optional[date], bool]:
+        """Return Winter Solstice (22nd solar term in Chinese Lunisolar calendar) date.
+
+        !!! note "Note"
+            This approximation is reliable for 1941-2099 years.
+        """
+        calendar = calendar or self.__calendar
+        self.__verify_calendar(calendar)
+
+        calendar_thresholds = {
+            # UTC+7.
+            VIETNAMESE_CALENDAR: {
+                "dec23_thresholds": (3, 1943),
+                "dec21_thresholds": {0: 1980, 1: 2017, 2: 2050, 3: 2083},
+            },
+            # UTC+8.
+            CHINESE_CALENDAR: {
+                "dec23_thresholds": (3, 1947),
+                "dec21_thresholds": {0: 1988, 1: 2021, 2: 2058, 3: 2091},
+            },
+            # UTC+9.
+            KOREAN_CALENDAR: {
+                "dec23_thresholds": (3, 1955),
+                "dec21_thresholds": {0: 1992, 1: 2029, 2: 2062, 3: 2099},
+            },
+        }
+
+        thresholds = calendar_thresholds[calendar]
+        dec23_thresholds = thresholds["dec23_thresholds"]
+        dec21_thresholds = thresholds["dec21_thresholds"]
+        year_mod = year % 4
+        if year_mod == dec23_thresholds[0] and year <= dec23_thresholds[1]:  # type: ignore[index]
+            day = 23
+        elif year >= dec21_thresholds[year_mod]:  # type: ignore[index]
+            day = 21
+        else:
+            day = 22
+
+        return date(year, DEC, day), False
 
 
 class _CustomChineseHolidays(_CustomCalendar, _ChineseLunisolar):

--- a/holidays/calendars/chinese.py
+++ b/holidays/calendars/chinese.py
@@ -1310,18 +1310,18 @@ class _ChineseLunisolar:
     WINTER_SOLSTICE_THRESHOLDS: dict[str, dict[str, dict[int, int]]] = {
         # UTC+7.
         VIETNAMESE_CALENDAR: {
-            "dec23_thresholds": {3: 1943},
-            "dec21_thresholds": {0: 1980, 1: 2017, 2: 2050, 3: 2083},
+            "dec21": {0: 1980, 1: 2017, 2: 2050, 3: 2083},
+            "dec23": {3: 1943},
         },
         # UTC+8.
         CHINESE_CALENDAR: {
-            "dec23_thresholds": {3: 1947},
-            "dec21_thresholds": {0: 1988, 1: 2021, 2: 2058, 3: 2091},
+            "dec21": {0: 1988, 1: 2021, 2: 2058, 3: 2091},
+            "dec23": {3: 1947},
         },
         # UTC+9.
         KOREAN_CALENDAR: {
-            "dec23_thresholds": {3: 1955},
-            "dec21_thresholds": {0: 1992, 1: 2029, 2: 2062, 3: 2099},
+            "dec21": {0: 1992, 1: 2029, 2: 2062, 3: 2099},
+            "dec23": {3: 1955},
         },
     }
 
@@ -1388,10 +1388,10 @@ class _ChineseLunisolar:
 
         thresholds = self.WINTER_SOLSTICE_THRESHOLDS[calendar]
         year_mod = year % 4
-        if year <= thresholds["dec23_thresholds"].get(year_mod, 0):
-            day = 23
-        elif year >= thresholds["dec21_thresholds"][year_mod]:
+        if year >= thresholds["dec21"][year_mod]:
             day = 21
+        elif year <= thresholds["dec23"].get(year_mod, 0):
+            day = 23
         else:
             day = 22
 

--- a/holidays/calendars/chinese.py
+++ b/holidays/calendars/chinese.py
@@ -1310,18 +1310,18 @@ class _ChineseLunisolar:
     WINTER_SOLSTICE_THRESHOLDS: dict[str, dict[str, dict[int, int]]] = {
         # UTC+7.
         VIETNAMESE_CALENDAR: {
-            "dec21": {0: 1980, 1: 2017, 2: 2050, 3: 2083},
-            "dec23": {3: 1943},
+            "dec_21": {0: 1980, 1: 2017, 2: 2050, 3: 2083},
+            "dec_23": {3: 1943},
         },
         # UTC+8.
         CHINESE_CALENDAR: {
-            "dec21": {0: 1988, 1: 2021, 2: 2058, 3: 2091},
-            "dec23": {3: 1947},
+            "dec_21": {0: 1988, 1: 2021, 2: 2058, 3: 2091},
+            "dec_23": {3: 1947},
         },
         # UTC+9.
         KOREAN_CALENDAR: {
-            "dec21": {0: 1992, 1: 2029, 2: 2062, 3: 2099},
-            "dec23": {3: 1955},
+            "dec_21": {0: 1992, 1: 2029, 2: 2062, 3: 2099},
+            "dec_23": {3: 1955},
         },
     }
 
@@ -1388,9 +1388,9 @@ class _ChineseLunisolar:
 
         thresholds = self.WINTER_SOLSTICE_THRESHOLDS[calendar]
         year_mod = year % 4
-        if year >= thresholds["dec21"][year_mod]:
+        if year >= thresholds["dec_21"][year_mod]:
             day = 21
-        elif year <= thresholds["dec23"].get(year_mod, 0):
+        elif year <= thresholds["dec_23"].get(year_mod, 0):
             day = 23
         else:
             day = 22

--- a/holidays/calendars/chinese.py
+++ b/holidays/calendars/chinese.py
@@ -1307,20 +1307,20 @@ class _ChineseLunisolar:
         2053: (FEB, 18),
     }
 
-    WINTER_SOLSTICE_THRESHOLDS = {
+    WINTER_SOLSTICE_THRESHOLDS: dict[str, dict[str, dict[int, int]]] = {
         # UTC+7.
         VIETNAMESE_CALENDAR: {
-            "dec23_thresholds": (3, 1943),
+            "dec23_thresholds": {3: 1943},
             "dec21_thresholds": {0: 1980, 1: 2017, 2: 2050, 3: 2083},
         },
         # UTC+8.
         CHINESE_CALENDAR: {
-            "dec23_thresholds": (3, 1947),
+            "dec23_thresholds": {3: 1947},
             "dec21_thresholds": {0: 1988, 1: 2021, 2: 2058, 3: 2091},
         },
         # UTC+9.
         KOREAN_CALENDAR: {
-            "dec23_thresholds": (3, 1955),
+            "dec23_thresholds": {3: 1955},
             "dec21_thresholds": {0: 1992, 1: 2029, 2: 2062, 3: 2099},
         },
     }
@@ -1387,17 +1387,15 @@ class _ChineseLunisolar:
         self.__verify_calendar(calendar)
 
         thresholds = self.WINTER_SOLSTICE_THRESHOLDS[calendar]
-        dec23_thresholds = thresholds["dec23_thresholds"]
-        dec21_thresholds = thresholds["dec21_thresholds"]
         year_mod = year % 4
-        if year_mod == dec23_thresholds[0] and year <= dec23_thresholds[1]:  # type: ignore[index]
+        if year <= thresholds["dec23_thresholds"].get(year_mod, 0):
             day = 23
-        elif year >= dec21_thresholds[year_mod]:  # type: ignore[index]
+        elif year >= thresholds["dec21_thresholds"][year_mod]:
             day = 21
         else:
             day = 22
 
-        return date(year, DEC, day), False
+        return date(year, DEC, day), not (1941 <= year <= 2099)
 
 
 class _CustomChineseHolidays(_CustomCalendar, _ChineseLunisolar):

--- a/holidays/calendars/chinese.py
+++ b/holidays/calendars/chinese.py
@@ -1307,6 +1307,24 @@ class _ChineseLunisolar:
         2053: (FEB, 18),
     }
 
+    WINTER_SOLSTICE_THRESHOLDS = {
+        # UTC+7.
+        VIETNAMESE_CALENDAR: {
+            "dec23_thresholds": (3, 1943),
+            "dec21_thresholds": {0: 1980, 1: 2017, 2: 2050, 3: 2083},
+        },
+        # UTC+8.
+        CHINESE_CALENDAR: {
+            "dec23_thresholds": (3, 1947),
+            "dec21_thresholds": {0: 1988, 1: 2021, 2: 2058, 3: 2091},
+        },
+        # UTC+9.
+        KOREAN_CALENDAR: {
+            "dec23_thresholds": (3, 1955),
+            "dec21_thresholds": {0: 1992, 1: 2029, 2: 2062, 3: 2099},
+        },
+    }
+
     def __init__(self, calendar: str = CHINESE_CALENDAR) -> None:
         self.__verify_calendar(calendar)
         self.__calendar = calendar
@@ -1368,25 +1386,7 @@ class _ChineseLunisolar:
         calendar = calendar or self.__calendar
         self.__verify_calendar(calendar)
 
-        calendar_thresholds = {
-            # UTC+7.
-            VIETNAMESE_CALENDAR: {
-                "dec23_thresholds": (3, 1943),
-                "dec21_thresholds": {0: 1980, 1: 2017, 2: 2050, 3: 2083},
-            },
-            # UTC+8.
-            CHINESE_CALENDAR: {
-                "dec23_thresholds": (3, 1947),
-                "dec21_thresholds": {0: 1988, 1: 2021, 2: 2058, 3: 2091},
-            },
-            # UTC+9.
-            KOREAN_CALENDAR: {
-                "dec23_thresholds": (3, 1955),
-                "dec21_thresholds": {0: 1992, 1: 2029, 2: 2062, 3: 2099},
-            },
-        }
-
-        thresholds = calendar_thresholds[calendar]
+        thresholds = self.WINTER_SOLSTICE_THRESHOLDS[calendar]
         dec23_thresholds = thresholds["dec23_thresholds"]
         dec21_thresholds = thresholds["dec21_thresholds"]
         year_mod = year % 4

--- a/holidays/groups/chinese.py
+++ b/holidays/groups/chinese.py
@@ -14,7 +14,7 @@ from datetime import date
 from typing import Optional
 
 from holidays.calendars.chinese import _ChineseLunisolar, CHINESE_CALENDAR
-from holidays.calendars.gregorian import APR, DEC
+from holidays.calendars.gregorian import APR
 from holidays.groups.eastern import EasternCalendarHolidays
 
 
@@ -79,20 +79,8 @@ class ChineseCalendarHolidays(EasternCalendarHolidays):
     def _dongzhi_festival(self):
         """
         Return Dongzhi Festival (Chinese Winter Solstice) date.
-
-        This approximation is reliable for 1952-2099 years.
         """
-        #
-        if (
-            (self._year % 4 == 0 and self._year >= 1988)
-            or (self._year % 4 == 1 and self._year >= 2021)
-            or (self._year % 4 == 2 and self._year >= 2058)
-            or (self._year % 4 == 3 and self._year >= 2091)
-        ):
-            day = 21
-        else:
-            day = 22
-        return date(self._year, DEC, day)
+        return self._chinese_calendar.winter_solstice_date(self._year)[0]
 
     def _add_chinese_calendar_holiday(
         self, name: str, dt_estimated: tuple[Optional[date], bool], days_delta: int = 0

--- a/tests/calendars/test_chinese.py
+++ b/tests/calendars/test_chinese.py
@@ -17,7 +17,7 @@ from holidays.calendars.chinese import _ChineseLunisolar, KOREAN_CALENDAR, VIETN
 
 class TestChineseLunisolarCalendar(unittest.TestCase):
     def setUp(self) -> None:
-        super().setUpClass()
+        super().setUp()
         self.calendar = _ChineseLunisolar()
 
     def test_check_calendar(self):

--- a/tests/calendars/test_chinese.py
+++ b/tests/calendars/test_chinese.py
@@ -12,15 +12,18 @@
 
 import unittest
 
-from holidays.calendars.chinese import _ChineseLunisolar
+from holidays.calendars.chinese import _ChineseLunisolar, KOREAN_CALENDAR, VIETNAMESE_CALENDAR
 
 
 class TestChineseLunisolarCalendar(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUpClass()
+        self.calendar = _ChineseLunisolar()
+
     def test_check_calendar(self):
         self.assertRaises(ValueError, lambda: _ChineseLunisolar("INVALID_CALENDAR"))
 
-    def test_winter_solstice(self):
-        cnls = _ChineseLunisolar()
+    def test_winter_solstice_chinese(self):
         for year, day in (
             (1943, 23),
             (1947, 23),
@@ -38,4 +41,48 @@ class TestChineseLunisolarCalendar(unittest.TestCase):
             (2091, 21),
             (2095, 21),
         ):
-            self.assertEqual(cnls.winter_solstice_date(year)[0].day, day)
+            self.assertEqual(self.calendar.winter_solstice_date(year)[0].day, day)
+
+    def test_winter_solstice_korean(self):
+        for year, day in (
+            (1951, 23),
+            (1955, 23),
+            (1959, 22),
+            (1988, 22),
+            (1992, 21),
+            (1996, 21),
+            (2025, 22),
+            (2029, 21),
+            (2033, 21),
+            (2058, 22),
+            (2062, 21),
+            (2066, 21),
+            (2095, 22),
+            (2099, 21),
+        ):
+            self.assertEqual(self.calendar.winter_solstice_date(year, KOREAN_CALENDAR)[0].day, day)
+
+    def test_winter_solstice_vietnamese(self):
+        for year, day in (
+            (1943, 23),
+            (1947, 22),
+            (1976, 22),
+            (1980, 21),
+            (1984, 21),
+            (2013, 22),
+            (2017, 21),
+            (2021, 21),
+            (2046, 22),
+            (2050, 21),
+            (2054, 21),
+            (2079, 22),
+            (2083, 21),
+            (2087, 21),
+        ):
+            self.assertEqual(
+                self.calendar.winter_solstice_date(year, VIETNAMESE_CALENDAR)[0].day, day
+            )
+
+    def test_winter_solstice_estimated(self):
+        for year in (1940, 2100):
+            self.assertTrue(self.calendar.winter_solstice_date(year)[1])

--- a/tests/calendars/test_chinese.py
+++ b/tests/calendars/test_chinese.py
@@ -18,3 +18,24 @@ from holidays.calendars.chinese import _ChineseLunisolar
 class TestChineseLunisolarCalendar(unittest.TestCase):
     def test_check_calendar(self):
         self.assertRaises(ValueError, lambda: _ChineseLunisolar("INVALID_CALENDAR"))
+
+    def test_winter_solstice(self):
+        cnls = _ChineseLunisolar()
+        for year, day in (
+            (1943, 23),
+            (1947, 23),
+            (1951, 22),
+            (1984, 22),
+            (1988, 21),
+            (1992, 21),
+            (2017, 22),
+            (2021, 21),
+            (2025, 21),
+            (2054, 22),
+            (2058, 21),
+            (2062, 21),
+            (2087, 22),
+            (2091, 21),
+            (2095, 21),
+        ):
+            self.assertEqual(cnls.winter_solstice_date(year)[0].day, day)

--- a/tests/calendars/test_chinese.py
+++ b/tests/calendars/test_chinese.py
@@ -86,3 +86,5 @@ class TestChineseLunisolarCalendar(unittest.TestCase):
     def test_winter_solstice_estimated(self):
         for year in (1940, 2100):
             self.assertTrue(self.calendar.winter_solstice_date(year)[1])
+        for year in (1941, 2099):
+            self.assertFalse(self.calendar.winter_solstice_date(year)[1])


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Update Chinese Lunisolar calendar: extend Winter solstice support (for Korean and Vietnamese calendar).
North Korea has holidays related to the Winter Solstice. Vietnam doesn't have such holidays, but support has been added for consistency.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
