### PR TITLE
Update Djibouti holidays: change holiday groups MRO

### DIFF
--- a/holidays/countries/djibouti.py
+++ b/holidays/countries/djibouti.py
@@ -17,7 +17,7 @@ from holidays.groups import ChristianHolidays, IslamicHolidays, InternationalHol
 from holidays.holiday_base import HolidayBase
 
 
-class Djibouti(HolidayBase, ChristianHolidays, IslamicHolidays, InternationalHolidays):
+class Djibouti(HolidayBase, ChristianHolidays, InternationalHolidays, IslamicHolidays):
     """Djibouti holidays."""
 
     country = "DJ"


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

As raised by coderabbitai during #2928's code review:

> - Benin: HolidayBase, ChristianHolidays, InternationalHolidays, IslamicHolidays ✅ (alphabetical)
> - Burkina Faso: ObservedHolidayBase, ChristianHolidays, InternationalHolidays, IslamicHolidays ✅ (alphabetical)
> - Burundi: ObservedHolidayBase, ChristianHolidays, InternationalHolidays, IslamicHolidays ✅ (alphabetical)
> - Eritrea: HolidayBase, ChristianHolidays, InternationalHolidays, IslamicHolidays ✅ (alphabetical)
> - Djibouti: HolidayBase, ChristianHolidays, IslamicHolidays, InternationalHolidays ❌ (not alphabetical - appears to be an outlier)
>
> Your Algeria implementation with HolidayBase, ChristianHolidays, HebrewCalendarHolidays, InternationalHolidays, IslamicHolidays perfectly follows the alphabetical convention:

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
