### PR TITLE
Update Sweden holidays: add legally-recognized non-public holidays as `DE_FACTO` category

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -165,6 +165,7 @@ Tommy Sparber
 Tudor Văran
 Victor Luna
 Victor Miti
+Viktor Rosvall
 Ville Skyttä
 Vilmos Prokaj
 Vu Nhat Chuong

--- a/README.md
+++ b/README.md
@@ -1643,7 +1643,7 @@ any) in brackets, available languages and additional holiday categories. All cou
 <td>SE</td>
 <td></td>
 <td>en_US, <strong>sv</strong>, th, uk</td>
-<td>BANK, OPTIONAL</td>
+<td>BANK, DE_FACTO, OPTIONAL</td>
 </tr>
 <tr>
 <td>Switzerland</td>

--- a/docs/holiday_categories.md
+++ b/docs/holiday_categories.md
@@ -101,6 +101,25 @@ Examples:
 - Christmas Eve (afternoon only)
 - New Year's Eve (afternoon only)
 
+#### DE_FACTO
+
+Holidays that are legally treated equivalently to public holidays for specific purposes (such as working day calculations) but are not officially designated as public holidays. These observances have legal backing that grants them similar status to public holidays in certain contexts.
+
+Examples:
+
+- **Sweden**: Midsummer Eve (Midsommarafton), Christmas Eve (Julafton), and New Year's Eve (Nyårsafton) - per Swedish Annual Leave Law (SFS 1977:480), these are treated equivalently to Sundays and public holidays for working day calculations, though they are not official public holidays.
+
+Usage:
+
+```python
+import holidays
+from holidays.constants import PUBLIC, DE_FACTO
+
+# For accurate is_working_day() behavior in Sweden
+se = holidays.Sweden(categories=(PUBLIC, DE_FACTO), years=2024)
+print(se.is_working_day('2024-12-24'))  # False (Christmas Eve)
+```
+
 ### Religious Categories
 
 #### CATHOLIC
@@ -344,6 +363,7 @@ When adding support for a new country, consider:
 - **GOVERNMENT**: Official observances without general time off
 - **WORKDAY**: Recognized but working holidays
 - **UNOFFICIAL**: Widely celebrated but not official
+- **DE_FACTO**: Legally recognized holidays that must be treated like public holidays for specific purposes (e.g., working day calculations) but lack official public holiday status
 - **Religious categories**: Use specific tradition names when holidays apply to particular communities
 - **Institutional categories**: Use when holidays apply to specific sectors
 

--- a/holidays/constants.py
+++ b/holidays/constants.py
@@ -38,6 +38,7 @@ HOLIDAY_NAME_DELIMITER = "; "  # Holiday names separator.
 # Supported holiday categories.
 ARMED_FORCES = "armed_forces"
 BANK = "bank"
+DE_FACTO = "de_facto"
 GOVERNMENT = "government"
 HALF_DAY = "half_day"
 OPTIONAL = "optional"

--- a/holidays/countries/sweden.py
+++ b/holidays/countries/sweden.py
@@ -149,14 +149,7 @@ class Sweden(HolidayBase, ChristianHolidays, InternationalHolidays):
                 self._add_holiday(tr("Söndag"), dt)
 
     def _populate_de_facto_holidays(self):
-        """
-        Populate de facto holidays.
-
-        These holidays are treated equivalently to public holidays for working
-        day calculations according to Swedish Annual Leave Law (SFS 1977:480),
-        but are not official public holidays.
-        """
-        # Midsummer Eve (Friday between June 19 and 25).
+        # Midsummer Eve
         self._add_holiday_1st_fri_from_jun_19(tr("Midsommarafton"))
 
         # Christmas Eve.
@@ -184,6 +177,7 @@ class Sweden(HolidayBase, ChristianHolidays, InternationalHolidays):
 
     def _populate_bank_holidays(self):
         self._populate_common()
+        self._populate_de_facto_holidays()
 
         self._add_holiday_38_days_past_easter(
             # Day before Ascension Day.

--- a/holidays/countries/sweden.py
+++ b/holidays/countries/sweden.py
@@ -149,7 +149,7 @@ class Sweden(HolidayBase, ChristianHolidays, InternationalHolidays):
                 self._add_holiday(tr("Söndag"), dt)
 
     def _populate_de_facto_holidays(self):
-        # Midsummer Eve
+        # Midsummer Eve.
         self._add_holiday_1st_fri_from_jun_19(tr("Midsommarafton"))
 
         # Christmas Eve.

--- a/holidays/countries/sweden.py
+++ b/holidays/countries/sweden.py
@@ -20,7 +20,7 @@ from holidays.calendars.gregorian import (
     _get_nth_weekday_from,
     _timedelta,
 )
-from holidays.constants import BANK, OPTIONAL, PUBLIC
+from holidays.constants import BANK, DE_FACTO, OPTIONAL, PUBLIC
 from holidays.groups import ChristianHolidays, InternationalHolidays
 from holidays.holiday_base import HolidayBase
 
@@ -37,9 +37,31 @@ class Sweden(HolidayBase, ChristianHolidays, InternationalHolidays):
         * <https://sv.wikipedia.org/wiki/Sveriges_nationaldag>
         * <https://sv.wikipedia.org/wiki/Midsommarafton>
         * [Bank Holidays 2025](https://web.archive.org/web/20250811112642/https://www.riksbank.se/sv/press-och-publicerat/kalender/helgdagar-2025/)
+        * [Swedish Annual Leave Law (SFS 1977:480)](https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/semesterlag-1977480_sfs-1977-480/)
 
     In Sweden, ALL sundays are considered a holiday.
     Initialize this class with `include_sundays=False` to not include sundays as a holiday.
+
+    Supported holiday categories:
+
+    - PUBLIC: Official public holidays with general time off
+    - DE_FACTO: Holidays treated equivalently to public holidays by law
+    - BANK: Banking institution holidays
+    - OPTIONAL: Optional or cultural observances
+
+    The DE_FACTO category includes:
+        - Midsommarafton (Midsummer Eve)
+        - Julafton (Christmas Eve)
+        - Nyårsafton (New Year's Eve)
+
+    According to Swedish Annual Leave Law (SFS 1977:480, Section 7): "Med söndag
+    jämställs allmän helgdag samt midsommarafton, julafton och nyårsafton"
+    (Sundays are equivalent to public holidays as well as Midsummer's Eve,
+    Christmas Eve, and New Year's Eve).
+
+    These holidays are not official public holidays but must be treated as
+    non-working days. For accurate `is_working_day()` calculations, use:
+        `Sweden(categories=(PUBLIC, DE_FACTO))`
     """
 
     # %s (from 2pm).
@@ -48,7 +70,7 @@ class Sweden(HolidayBase, ChristianHolidays, InternationalHolidays):
     default_language = "sv"
     # Act 1952:48.
     start_year = 1953
-    supported_categories = (BANK, OPTIONAL, PUBLIC)
+    supported_categories = (BANK, DE_FACTO, OPTIONAL, PUBLIC)
     supported_languages = ("en_US", "sv", "th", "uk")
 
     def __init__(self, *args, include_sundays: bool = True, **kwargs):
@@ -126,6 +148,23 @@ class Sweden(HolidayBase, ChristianHolidays, InternationalHolidays):
                 # Sunday.
                 self._add_holiday(tr("Söndag"), dt)
 
+    def _populate_de_facto_holidays(self):
+        """
+        Populate de facto holidays.
+
+        These holidays are treated equivalently to public holidays for working
+        day calculations according to Swedish Annual Leave Law (SFS 1977:480),
+        but are not official public holidays.
+        """
+        # Midsummer Eve (Friday between June 19 and 25).
+        self._add_holiday_1st_fri_from_jun_19(tr("Midsommarafton"))
+
+        # Christmas Eve.
+        self._add_christmas_eve(tr("Julafton"))
+
+        # New Year's Eve.
+        self._add_new_years_eve(tr("Nyårsafton"))
+
     def _populate_common(self):
         """Populate holidays that are both optional and bank holidays."""
 
@@ -138,19 +177,10 @@ class Sweden(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Walpurgis Night.
         self._add_holiday_apr_30(self.tr(self.begin_time_label) % self.tr("Valborgsmässoafton"))
 
-        # Midsummer Eve.
-        self._add_holiday_1st_fri_from_jun_19(tr("Midsommarafton"))
-
         self._add_holiday_1st_fri_from_oct_30(
             # All Saints' Eve.
             self.tr(self.begin_time_label) % self.tr("Allahelgonsafton")
         )
-
-        # Christmas Eve.
-        self._add_christmas_eve(tr("Julafton"))
-
-        # New Year's Eve.
-        self._add_new_years_eve(tr("Nyårsafton"))
 
     def _populate_bank_holidays(self):
         self._populate_common()

--- a/holidays/locale/en_US/LC_MESSAGES/SE.po
+++ b/holidays/locale/en_US/LC_MESSAGES/SE.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.86\n"
+"Project-Id-Version: Holidays 0.87\n"
 "POT-Creation-Date: 2023-04-08 20:17+0300\n"
 "PO-Revision-Date: 2025-11-25 23:05+0200\n"
 "Last-Translator: ~Jhellico <jhellico@gmail.com>\n"
@@ -96,6 +96,18 @@ msgstr "Second Day of Christmas"
 msgid "Söndag"
 msgstr "Sunday"
 
+#. Midsummer Eve (Friday between June 19 and 25).
+msgid "Midsommarafton"
+msgstr "Midsummer Eve"
+
+#. Christmas Eve.
+msgid "Julafton"
+msgstr "Christmas Eve"
+
+#. New Year's Eve.
+msgid "Nyårsafton"
+msgstr "New Year's Eve"
+
 #. Twelfth Night.
 msgid "Trettondagsafton"
 msgstr "Twelfth Night"
@@ -108,21 +120,9 @@ msgstr "Maundy Thursday"
 msgid "Valborgsmässoafton"
 msgstr "Walpurgis Night"
 
-#. Midsummer Eve.
-msgid "Midsommarafton"
-msgstr "Midsummer Eve"
-
 #. All Saints' Eve.
 msgid "Allahelgonsafton"
 msgstr "All Saints' Eve"
-
-#. Christmas Eve.
-msgid "Julafton"
-msgstr "Christmas Eve"
-
-#. New Year's Eve.
-msgid "Nyårsafton"
-msgstr "New Year's Eve"
 
 #. Day before Ascension Day.
 msgid "Dag före Kristi himmelsfärdsdag"

--- a/holidays/locale/en_US/LC_MESSAGES/SE.po
+++ b/holidays/locale/en_US/LC_MESSAGES/SE.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.87\n"
+"Project-Id-Version: Holidays 0.88\n"
 "POT-Creation-Date: 2023-04-08 20:17+0300\n"
 "PO-Revision-Date: 2025-11-25 23:05+0200\n"
 "Last-Translator: ~Jhellico <jhellico@gmail.com>\n"

--- a/holidays/locale/en_US/LC_MESSAGES/SE.po
+++ b/holidays/locale/en_US/LC_MESSAGES/SE.po
@@ -96,7 +96,7 @@ msgstr "Second Day of Christmas"
 msgid "Söndag"
 msgstr "Sunday"
 
-#. Midsummer Eve
+#. Midsummer Eve.
 msgid "Midsommarafton"
 msgstr "Midsummer Eve"
 

--- a/holidays/locale/en_US/LC_MESSAGES/SE.po
+++ b/holidays/locale/en_US/LC_MESSAGES/SE.po
@@ -96,7 +96,7 @@ msgstr "Second Day of Christmas"
 msgid "Söndag"
 msgstr "Sunday"
 
-#. Midsummer Eve (Friday between June 19 and 25).
+#. Midsummer Eve
 msgid "Midsommarafton"
 msgstr "Midsummer Eve"
 

--- a/holidays/locale/sv/LC_MESSAGES/SE.po
+++ b/holidays/locale/sv/LC_MESSAGES/SE.po
@@ -96,7 +96,7 @@ msgstr ""
 msgid "Söndag"
 msgstr ""
 
-#. Midsummer Eve (Friday between June 19 and 25).
+#. Midsummer Eve
 msgid "Midsommarafton"
 msgstr ""
 

--- a/holidays/locale/sv/LC_MESSAGES/SE.po
+++ b/holidays/locale/sv/LC_MESSAGES/SE.po
@@ -96,7 +96,7 @@ msgstr ""
 msgid "Söndag"
 msgstr ""
 
-#. Midsummer Eve
+#. Midsummer Eve.
 msgid "Midsommarafton"
 msgstr ""
 

--- a/holidays/locale/sv/LC_MESSAGES/SE.po
+++ b/holidays/locale/sv/LC_MESSAGES/SE.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.87\n"
+"Project-Id-Version: Holidays 0.88\n"
 "POT-Creation-Date: 2023-04-08 20:17+0300\n"
 "PO-Revision-Date: 2025-11-25 23:04+0200\n"
 "Last-Translator: ~Jhellico <jhellico@gmail.com>\n"

--- a/holidays/locale/sv/LC_MESSAGES/SE.po
+++ b/holidays/locale/sv/LC_MESSAGES/SE.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.86\n"
+"Project-Id-Version: Holidays 0.87\n"
 "POT-Creation-Date: 2023-04-08 20:17+0300\n"
 "PO-Revision-Date: 2025-11-25 23:04+0200\n"
 "Last-Translator: ~Jhellico <jhellico@gmail.com>\n"
@@ -96,6 +96,18 @@ msgstr ""
 msgid "Söndag"
 msgstr ""
 
+#. Midsummer Eve (Friday between June 19 and 25).
+msgid "Midsommarafton"
+msgstr ""
+
+#. Christmas Eve.
+msgid "Julafton"
+msgstr ""
+
+#. New Year's Eve.
+msgid "Nyårsafton"
+msgstr ""
+
 #. Twelfth Night.
 msgid "Trettondagsafton"
 msgstr ""
@@ -108,20 +120,8 @@ msgstr ""
 msgid "Valborgsmässoafton"
 msgstr ""
 
-#. Midsummer Eve.
-msgid "Midsommarafton"
-msgstr ""
-
 #. All Saints' Eve.
 msgid "Allahelgonsafton"
-msgstr ""
-
-#. Christmas Eve.
-msgid "Julafton"
-msgstr ""
-
-#. New Year's Eve.
-msgid "Nyårsafton"
 msgstr ""
 
 #. Day before Ascension Day.

--- a/holidays/locale/th/LC_MESSAGES/SE.po
+++ b/holidays/locale/th/LC_MESSAGES/SE.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.86\n"
+"Project-Id-Version: Holidays 0.87\n"
 "POT-Creation-Date: 2024-10-01 14:12+0700\n"
 "PO-Revision-Date: 2025-11-25 23:05+0200\n"
 "Last-Translator: ~Jhellico <jhellico@gmail.com>\n"
@@ -96,6 +96,18 @@ msgstr "วันคริสต์มาสวันที่สอง"
 msgid "Söndag"
 msgstr "วันอาทิตย์"
 
+#. Midsummer Eve (Friday between June 19 and 25).
+msgid "Midsommarafton"
+msgstr "วันก่อนวันกลางฤดูร้อน"
+
+#. Christmas Eve.
+msgid "Julafton"
+msgstr "วันคริสต์มาสอีฟ"
+
+#. New Year's Eve.
+msgid "Nyårsafton"
+msgstr "วันสิ้นปี"
+
 #. Twelfth Night.
 msgid "Trettondagsafton"
 msgstr "วันก่อนวันสมโภชพระคริสต์แสดงองค์"
@@ -108,21 +120,9 @@ msgstr "วันพฤหัสศักดิ์สิทธิ์"
 msgid "Valborgsmässoafton"
 msgstr "คืนวัลเพอร์กิส"
 
-#. Midsummer Eve.
-msgid "Midsommarafton"
-msgstr "วันก่อนวันกลางฤดูร้อน"
-
 #. All Saints' Eve.
 msgid "Allahelgonsafton"
 msgstr "วันก่อนวันสมโภชนักบุญทั้งหลาย"
-
-#. Christmas Eve.
-msgid "Julafton"
-msgstr "วันคริสต์มาสอีฟ"
-
-#. New Year's Eve.
-msgid "Nyårsafton"
-msgstr "วันสิ้นปี"
 
 #. Day before Ascension Day.
 msgid "Dag före Kristi himmelsfärdsdag"

--- a/holidays/locale/th/LC_MESSAGES/SE.po
+++ b/holidays/locale/th/LC_MESSAGES/SE.po
@@ -96,7 +96,7 @@ msgstr "วันคริสต์มาสวันที่สอง"
 msgid "Söndag"
 msgstr "วันอาทิตย์"
 
-#. Midsummer Eve
+#. Midsummer Eve.
 msgid "Midsommarafton"
 msgstr "วันก่อนวันกลางฤดูร้อน"
 

--- a/holidays/locale/th/LC_MESSAGES/SE.po
+++ b/holidays/locale/th/LC_MESSAGES/SE.po
@@ -96,7 +96,7 @@ msgstr "วันคริสต์มาสวันที่สอง"
 msgid "Söndag"
 msgstr "วันอาทิตย์"
 
-#. Midsummer Eve (Friday between June 19 and 25).
+#. Midsummer Eve
 msgid "Midsommarafton"
 msgstr "วันก่อนวันกลางฤดูร้อน"
 

--- a/holidays/locale/th/LC_MESSAGES/SE.po
+++ b/holidays/locale/th/LC_MESSAGES/SE.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.87\n"
+"Project-Id-Version: Holidays 0.88\n"
 "POT-Creation-Date: 2024-10-01 14:12+0700\n"
 "PO-Revision-Date: 2025-11-25 23:05+0200\n"
 "Last-Translator: ~Jhellico <jhellico@gmail.com>\n"

--- a/holidays/locale/uk/LC_MESSAGES/SE.po
+++ b/holidays/locale/uk/LC_MESSAGES/SE.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.87\n"
+"Project-Id-Version: Holidays 0.88\n"
 "POT-Creation-Date: 2023-04-08 20:17+0300\n"
 "PO-Revision-Date: 2025-11-25 23:05+0200\n"
 "Last-Translator: ~Jhellico <jhellico@gmail.com>\n"

--- a/holidays/locale/uk/LC_MESSAGES/SE.po
+++ b/holidays/locale/uk/LC_MESSAGES/SE.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.86\n"
+"Project-Id-Version: Holidays 0.87\n"
 "POT-Creation-Date: 2023-04-08 20:17+0300\n"
 "PO-Revision-Date: 2025-11-25 23:05+0200\n"
 "Last-Translator: ~Jhellico <jhellico@gmail.com>\n"
@@ -96,6 +96,18 @@ msgstr "Другий день Різдва"
 msgid "Söndag"
 msgstr "Неділя"
 
+#. Midsummer Eve (Friday between June 19 and 25).
+msgid "Midsommarafton"
+msgstr "Переддень літнього сонцестояння"
+
+#. Christmas Eve.
+msgid "Julafton"
+msgstr "Святий вечір"
+
+#. New Year's Eve.
+msgid "Nyårsafton"
+msgstr "Переддень Нового року"
+
 #. Twelfth Night.
 msgid "Trettondagsafton"
 msgstr "Дванадцята ніч"
@@ -108,21 +120,9 @@ msgstr "Великий четвер"
 msgid "Valborgsmässoafton"
 msgstr "Вальпургієва ніч"
 
-#. Midsummer Eve.
-msgid "Midsommarafton"
-msgstr "Переддень літнього сонцестояння"
-
 #. All Saints' Eve.
 msgid "Allahelgonsafton"
 msgstr "Переддень Дня усіх святих"
-
-#. Christmas Eve.
-msgid "Julafton"
-msgstr "Святий вечір"
-
-#. New Year's Eve.
-msgid "Nyårsafton"
-msgstr "Переддень Нового року"
 
 #. Day before Ascension Day.
 msgid "Dag före Kristi himmelsfärdsdag"

--- a/holidays/locale/uk/LC_MESSAGES/SE.po
+++ b/holidays/locale/uk/LC_MESSAGES/SE.po
@@ -96,7 +96,7 @@ msgstr "Другий день Різдва"
 msgid "Söndag"
 msgstr "Неділя"
 
-#. Midsummer Eve (Friday between June 19 and 25).
+#. Midsummer Eve
 msgid "Midsommarafton"
 msgstr "Переддень літнього сонцестояння"
 

--- a/holidays/locale/uk/LC_MESSAGES/SE.po
+++ b/holidays/locale/uk/LC_MESSAGES/SE.po
@@ -96,7 +96,7 @@ msgstr "Другий день Різдва"
 msgid "Söndag"
 msgstr "Неділя"
 
-#. Midsummer Eve
+#. Midsummer Eve.
 msgid "Midsommarafton"
 msgstr "Переддень літнього сонцестояння"
 

--- a/tests/countries/test_sweden.py
+++ b/tests/countries/test_sweden.py
@@ -413,9 +413,8 @@ class TestSweden(CommonCountryTests, SundayHolidays, TestCase):
         )
 
     def test_de_facto_2022(self):
-        """Test all DE_FACTO holidays for 2022."""
-        self.assertHolidays(
-            Sweden(categories=DE_FACTO, years=2022),
+        self.assertDeFactoHolidaysInYear(
+            2022,
             ("2022-06-24", "Midsommarafton"),
             ("2022-12-24", "Julafton"),
             ("2022-12-31", "Nyårsafton"),

--- a/tests/countries/test_sweden.py
+++ b/tests/countries/test_sweden.py
@@ -12,7 +12,7 @@
 
 from unittest import TestCase
 
-from holidays.constants import BANK, OPTIONAL
+from holidays.constants import BANK, DE_FACTO, OPTIONAL
 from holidays.countries.sweden import Sweden
 from tests.common import CommonCountryTests, SundayHolidays
 
@@ -25,7 +25,9 @@ class TestSweden(CommonCountryTests, SundayHolidays, TestCase):
 
     def test_no_holidays(self):
         super().test_no_holidays()
-        self.assertNoHolidays(Sweden(categories=(BANK, OPTIONAL), years=self.start_year - 1))
+        self.assertNoHolidays(
+            Sweden(categories=(BANK, DE_FACTO, OPTIONAL), years=self.start_year - 1)
+        )
 
     def test_new_years_day(self):
         self.assertHolidayName("Nyårsdagen", (f"{year}-01-01" for year in self.full_range))
@@ -173,6 +175,79 @@ class TestSweden(CommonCountryTests, SundayHolidays, TestCase):
     def test_sundays(self):
         self.assertSundays(Sweden)  # Sundays are considered holidays in Sweden.
 
+    def test_de_facto_holidays(self):
+        """Test DE_FACTO category holidays."""
+        name_midsummer = "Midsommarafton"
+        name_christmas = "Julafton"
+        name_newyear = "Nyårsafton"
+
+        # These should NOT be in default (PUBLIC) category
+        self.assertNoHolidayName(name_midsummer)
+        self.assertNoHolidayName(name_christmas)
+        self.assertNoHolidayName(name_newyear)
+
+        # These should NOT be in BANK category
+        self.assertNoBankHolidayName(name_midsummer)
+        self.assertNoBankHolidayName(name_christmas)
+        self.assertNoBankHolidayName(name_newyear)
+
+        # These should NOT be in OPTIONAL category
+        self.assertNoOptionalHolidayName(name_midsummer)
+        self.assertNoOptionalHolidayName(name_christmas)
+        self.assertNoOptionalHolidayName(name_newyear)
+
+        # These SHOULD be in DE_FACTO category
+        # Midsummer Eve dates
+        dts_midsummer = (
+            "2020-06-19",
+            "2021-06-25",
+            "2022-06-24",
+            "2023-06-23",
+            "2024-06-21",
+            "2025-06-20",
+        )
+        self.assertDeFactoHolidayName(name_midsummer, dts_midsummer)
+
+        # Christmas Eve - every year
+        self.assertDeFactoHolidayName(
+            name_christmas, (f"{year}-12-24" for year in self.full_range)
+        )
+
+        # New Year's Eve - every year
+        self.assertDeFactoHolidayName(name_newyear, (f"{year}-12-31" for year in self.full_range))
+
+    def test_de_facto_2022(self):
+        """Test all DE_FACTO holidays for 2022."""
+        self.assertHolidays(
+            Sweden(categories=DE_FACTO, years=2022),
+            ("2022-06-24", "Midsommarafton"),
+            ("2022-12-24", "Julafton"),
+            ("2022-12-31", "Nyårsafton"),
+        )
+
+    def test_is_working_day_with_de_facto(self):
+        """Test that is_working_day() works correctly with DE_FACTO holidays."""
+        from holidays.constants import PUBLIC
+
+        # Use 2024: Christmas Eve is Tuesday, New Year's Eve is Tuesday, Midsummer Eve is Friday
+        # With only PUBLIC category (default)
+        se_public = Sweden(years=2024)
+        # These return True because they're not in PUBLIC category (and fall on weekdays)
+        self.assertTrue(se_public.is_working_day("2024-06-21"))  # Midsommarafton (Friday)
+        self.assertTrue(se_public.is_working_day("2024-12-24"))  # Julafton (Tuesday)
+        self.assertTrue(se_public.is_working_day("2024-12-31"))  # Nyårsafton (Tuesday)
+
+        # With PUBLIC + DE_FACTO categories (the fix)
+        se_all = Sweden(categories=(PUBLIC, DE_FACTO), years=2024)
+        # These should correctly return False
+        self.assertFalse(se_all.is_working_day("2024-06-21"))  # Midsommarafton
+        self.assertFalse(se_all.is_working_day("2024-12-24"))  # Julafton
+        self.assertFalse(se_all.is_working_day("2024-12-31"))  # Nyårsafton
+
+        # Public holidays should still be non-working
+        self.assertFalse(se_all.is_working_day("2024-12-25"))  # Juldagen
+        self.assertFalse(se_all.is_working_day("2024-01-01"))  # Nyårsdagen
+
     def test_twelfth_night(self):
         name = "Trettondagsafton (från kl. 14.00)"
         self.assertNoHolidayName(name)
@@ -204,6 +279,8 @@ class TestSweden(CommonCountryTests, SundayHolidays, TestCase):
     def test_midsummer_eve(self):
         name = "Midsommarafton"
         self.assertNoHolidayName(name)
+        self.assertNoBankHolidayName(name)
+        self.assertNoOptionalHolidayName(name)
         dts = (
             "2020-06-19",
             "2021-06-25",
@@ -212,10 +289,7 @@ class TestSweden(CommonCountryTests, SundayHolidays, TestCase):
             "2024-06-21",
             "2025-06-20",
         )
-        self.assertBankHolidayName(name, dts)
-        self.assertOptionalHolidayName(name, dts)
-        self.assertBankHolidayName(name, self.full_range)
-        self.assertOptionalHolidayName(name, self.full_range)
+        self.assertDeFactoHolidayName(name, dts)
 
     def test_all_saints_eve(self):
         name = "Allahelgonsafton (från kl. 14.00)"
@@ -236,14 +310,16 @@ class TestSweden(CommonCountryTests, SundayHolidays, TestCase):
     def test_christmas_eve(self):
         name = "Julafton"
         self.assertNoHolidayName(name)
-        self.assertBankHolidayName(name, (f"{year}-12-24" for year in self.full_range))
-        self.assertOptionalHolidayName(name, (f"{year}-12-24" for year in self.full_range))
+        self.assertNoBankHolidayName(name)
+        self.assertNoOptionalHolidayName(name)
+        self.assertDeFactoHolidayName(name, (f"{year}-12-24" for year in self.full_range))
 
     def test_new_years_eve(self):
         name = "Nyårsafton"
         self.assertNoHolidayName(name)
-        self.assertBankHolidayName(name, (f"{year}-12-31" for year in self.full_range))
-        self.assertOptionalHolidayName(name, (f"{year}-12-31" for year in self.full_range))
+        self.assertNoBankHolidayName(name)
+        self.assertNoOptionalHolidayName(name)
+        self.assertDeFactoHolidayName(name, (f"{year}-12-31" for year in self.full_range))
 
     def test_day_before_ascension_day(self):
         name = "Dag före Kristi himmelsfärdsdag (från kl. 14.00)"
@@ -387,12 +463,9 @@ class TestSweden(CommonCountryTests, SundayHolidays, TestCase):
             ("2022-05-25", "Dag före Kristi himmelsfärdsdag (från kl. 14.00)"),
             ("2022-06-03", "Dag före Pingstafton (från kl. 14.00)"),
             ("2022-06-23", "Dag före Midsommarafton (från kl. 14.00)"),
-            ("2022-06-24", "Midsommarafton"),
             ("2022-11-04", "Allahelgonsafton (från kl. 14.00)"),
             ("2022-12-23", "Dag före Julafton (från kl. 14.00)"),
-            ("2022-12-24", "Julafton"),
             ("2022-12-30", "Dag före Nyårsafton (från kl. 14.00)"),
-            ("2022-12-31", "Nyårsafton"),
         )
 
     def test_optional_2022(self):
@@ -404,10 +477,7 @@ class TestSweden(CommonCountryTests, SundayHolidays, TestCase):
             ("2022-04-30", "Valborgsmässoafton (från kl. 14.00)"),
             ("2022-05-27", "Klämdag"),
             ("2022-06-04", "Pingstafton"),
-            ("2022-06-24", "Midsommarafton"),
             ("2022-11-04", "Allahelgonsafton (från kl. 14.00)"),
-            ("2022-12-24", "Julafton"),
-            ("2022-12-31", "Nyårsafton"),
         )
 
     def test_l10n_default(self):


### PR DESCRIPTION
## Proposed change

This PR introduces a new `DE_FACTO` holiday category to address issue #3118 where `is_working_day()` incorrectly identified certain Swedish holidays as working days.

According to Swedish Annual Leave Law (SFS 1977:480), Midsummer's Eve, Christmas Eve, and New Year's Eve must be treated equivalently to Sundays and public holidays for working day calculations, even though they are not official public holidays.

### Changes

- **New category**: Added `DE_FACTO` constant in `holidays/constants.py` for holidays that are legally treated like public holidays but are not officially designated as such
- **Sweden implementation**: 
  - Moved Midsummer's Eve (Midsommarafton), Christmas Eve (Julafton), and New Year's Eve (Nyårsafton) from `BANK` and `OPTIONAL` categories to the new `DE_FACTO` category
  - Added `_populate_de_facto_holidays()` method to handle these special holidays
  - Updated supported categories to include `DE_FACTO`
- **Documentation**: Added comprehensive documentation in `docs/holiday_categories.md` explaining the new category with usage examples
- **Localization**: Updated all Swedish locale files (en_US, sv, th, uk)
- **Tests**: Added comprehensive test coverage including specific `is_working_day()` validation
- **README**: Updated to reflect the new category availability for Sweden

### Breaking Change
**This is a MINOR breaking change for Sweden holidays with the OPTIONAL category.**
**Previous behavior:**
- Midsummer's Eve, Christmas Eve, and New Year's Eve were included in both BANK and OPTIONAL categories
**New behavior:**
- These three holidays have been moved to the new DE_FACTO category
- They are still included in BANK category (via _populate_de_facto_holidays() call)
- They are NO LONGER included in OPTIONAL category
**Impact:**
- ✅ Users relying on categories=BANK will **continue to see** these three holidays (no breaking change)
- ⚠️ Users relying on categories=OPTIONAL will **no longer see** these three holidays (breaking change)
- Users need to explicitly include DE_FACTO category for accurate working day calculations: Sweden(categories=(PUBLIC, DE_FACTO))

**Rationale:**
These holidays are not optional holidays—they are legally mandated to be treated like public holidays for working day calculations per Swedish Annual Leave Law (SFS 1977:480). The Riksbank (Swedish central bank) also recognizes them as bank holidays.

### Usage

For accurate working day calculations in Sweden, use:

```python
import holidays
from holidays.constants import PUBLIC, DE_FACTO

se = holidays.Sweden(categories=(PUBLIC, DE_FACTO), years=2024)
print(se.is_working_day('2024-12-24'))  # False (Christmas Eve)
print(se.is_working_day('2024-12-31'))  # False (New Year's Eve)
print(se.is_working_day('2024-06-21'))  # False (Midsummer's Eve)
```

### Legal Reference

Per Swedish Annual Leave Law (SFS 1977:480, Section 7):
> "Med söndag jämställs allmän helgdag samt midsommarafton, julafton och nyårsafton"
> 
> (Sundays are equivalent to public holidays as well as Midsummer's Eve, Christmas Eve, and New Year's Eve)

Source: https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/semesterlag-1977480_sfs-1977-480/

Fixes #3118

## Type of change

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Breaking change (a code change causing existing functionality to break)
- [x] New feature (new `holidays` functionality in general)

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.
