### PR TITLE
IN: Add Dadra and Nagar Haveli and Daman and Diu (DH) holidays

### DIFF
--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -37,6 +37,9 @@ class India(
         * <https://web.archive.org/web/20250413193633/https://www.calendarlabs.com/holidays/india/2021>
         * <https://web.archive.org/web/20231118175007/http://slusi.dacnet.nic.in/watershedatlas/list_of_state_abbreviation.htm>
         * <https://web.archive.org/web/20231008063930/https://vahan.parivahan.gov.in/vahan4dashboard/>
+        * Dadra and Nagar Haveli and Daman and Diu :
+            * <http://web.archive.org/web/20250000000000*/https://en.wikipedia.org/wiki/Free_Dadra_and_Nagar_Haveli>
+            * <http://web.archive.org/web/20250000000000*/https://www.incredibleindia.gov.in/en/festivals-and-events/liberation-day>
         * Gujarat:
             * <https://gad.gujarat.gov.in/personnel/Images/pdf/general_holidays_2026_guj.pdf>
         * Tamil Nadu:
@@ -100,6 +103,7 @@ class India(
         "Chhattīsgarh": "CG",
         "Chandigarh": "CH",
         "Chandīgarh": "CH",
+        "DD": "DH",
         "Dadra and Nagar Haveli and Daman and Diu": "DH",
         "Dādra and Nagar Haveli and Damān and Diu": "DH",
         "Delhi": "DL",
@@ -317,6 +321,17 @@ class India(
         self._add_holiday_apr_14(tr("Dr. B. R. Ambedkar's Jayanti"))
         # Chhattisgarh Foundation Day.
         self._add_holiday_nov_1(tr("Chhattisgarh Foundation Day"))
+
+    # Dadra and Nagar Haveli and Daman and Diu.
+    def _populate_subdiv_dh_public_holidays(self):
+        # Dr. B. R. Ambedkar Jayanti.
+        self._add_holiday_apr_14(tr("Dr. B. R. Ambedkar's Jayanti"))
+
+        # Dadra and Nagar Haveli Liberation Day.
+        self._add_holiday_aug_2(tr("Dadra and Nagar Haveli Liberation Day"))
+
+        # Daman and Diu Liberation Day.
+        self._add_holiday_dec_19(tr("Daman and Diu Liberation Day"))
 
     # Delhi.
     def _populate_subdiv_dl_public_holidays(self):

--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -38,8 +38,8 @@ class India(
         * <https://web.archive.org/web/20231118175007/http://slusi.dacnet.nic.in/watershedatlas/list_of_state_abbreviation.htm>
         * <https://web.archive.org/web/20231008063930/https://vahan.parivahan.gov.in/vahan4dashboard/>
         * Dadra and Nagar Haveli and Daman and Diu :
-            * <http://web.archive.org/web/20250000000000*/https://en.wikipedia.org/wiki/Free_Dadra_and_Nagar_Haveli>
-            * <http://web.archive.org/web/20250000000000*/https://www.incredibleindia.gov.in/en/festivals-and-events/liberation-day>
+            * <https://web.archive.org/web/*/https://en.wikipedia.org/wiki/Free_Dadra_and_Nagar_Haveli>
+            * <https://web.archive.org/web/*/https://www.incredibleindia.gov.in/en/festivals-and-events/liberation-day>
         * Gujarat:
             * <https://gad.gujarat.gov.in/personnel/Images/pdf/general_holidays_2026_guj.pdf>
         * Tamil Nadu:

--- a/holidays/locale/en_IN/LC_MESSAGES/IN.po
+++ b/holidays/locale/en_IN/LC_MESSAGES/IN.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.82\n"
+"Project-Id-Version: Holidays 0.88\n"
 "POT-Creation-Date: 2025-02-28 02:31+0530\n"
 "PO-Revision-Date: 2025-03-01 15:11+0530\n"
 "Last-Translator: Ankush Kapoor <work.ankushkapoor1626@gmail.com>\n"
@@ -174,6 +174,14 @@ msgstr ""
 
 #. Chhattisgarh Foundation Day.
 msgid "Chhattisgarh Foundation Day"
+msgstr ""
+
+#. Dadra and Nagar Haveli Liberation Day.
+msgid "Dadra and Nagar Haveli Liberation Day"
+msgstr ""
+
+#. Daman and Diu Liberation Day.
+msgid "Daman and Diu Liberation Day"
 msgstr ""
 
 #. Goa Liberation Day.

--- a/holidays/locale/en_US/LC_MESSAGES/IN.po
+++ b/holidays/locale/en_US/LC_MESSAGES/IN.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.82\n"
+"Project-Id-Version: Holidays 0.88\n"
 "POT-Creation-Date: 2025-03-02 12:31+0530\n"
 "PO-Revision-Date: 2025-03-02 12:54+0530\n"
 "Last-Translator: Ankush Kapoor <work.ankushkapoor1626@gmail.com>\n"
@@ -175,6 +175,14 @@ msgstr "Bihar Day"
 #. Chhattisgarh Foundation Day.
 msgid "Chhattisgarh Foundation Day"
 msgstr "Chhattisgarh Foundation Day"
+
+#. Dadra and Nagar Haveli Liberation Day.
+msgid "Dadra and Nagar Haveli Liberation Day"
+msgstr ""
+
+#. Daman and Diu Liberation Day.
+msgid "Daman and Diu Liberation Day"
+msgstr ""
 
 #. Goa Liberation Day.
 msgid "Goa Liberation Day"

--- a/holidays/locale/gu/LC_MESSAGES/IN.po
+++ b/holidays/locale/gu/LC_MESSAGES/IN.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.87\n"
+"Project-Id-Version: Holidays 0.88\n"
 "POT-Creation-Date: 2025-02-28 01:24+0530\n"
 "PO-Revision-Date: 2025-03-01 15:11+0530\n"
 "Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
@@ -175,6 +175,14 @@ msgstr "બિહાર દિવસ"
 #. Chhattisgarh Foundation Day.
 msgid "Chhattisgarh Foundation Day"
 msgstr "છત્તીસગઢ સ્થાપના દિવસ"
+
+#. Dadra and Nagar Haveli Liberation Day.
+msgid "Dadra and Nagar Haveli Liberation Day"
+msgstr "દાદરા અને નગર હવેલી મુક્તિ દિવસ"
+
+#. Daman and Diu Liberation Day.
+msgid "Daman and Diu Liberation Day"
+msgstr "દમણ અને દીવ મુક્તિ દિવસ"
 
 #. Goa Liberation Day.
 msgid "Goa Liberation Day"

--- a/holidays/locale/hi/LC_MESSAGES/IN.po
+++ b/holidays/locale/hi/LC_MESSAGES/IN.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.82\n"
+"Project-Id-Version: Holidays 0.88\n"
 "POT-Creation-Date: 2025-02-28 01:24+0530\n"
 "PO-Revision-Date: 2025-03-01 15:11+0530\n"
 "Last-Translator: Ankush Kapoor <work.ankushkapoor1626@gmail.com>\n"
@@ -175,6 +175,14 @@ msgstr "बिहार दिवस"
 #. Chhattisgarh Foundation Day.
 msgid "Chhattisgarh Foundation Day"
 msgstr "छत्तीसगढ़ स्थापना दिवस"
+
+#. Dadra and Nagar Haveli Liberation Day.
+msgid "Dadra and Nagar Haveli Liberation Day"
+msgstr "दादरा और नगर हवेली मुक्ति दिवस"
+
+#. Daman and Diu Liberation Day.
+msgid "Daman and Diu Liberation Day"
+msgstr "दमन और दीव मुक्ति दिवस"
 
 #. Goa Liberation Day.
 msgid "Goa Liberation Day"

--- a/tests/countries/test_india.py
+++ b/tests/countries/test_india.py
@@ -72,6 +72,11 @@ class TestIndia(CommonCountryTests, TestCase):
                 "2018-11-01",
             ),
             "CH": ("2018-04-14",),
+            "DH": (
+                "2018-04-14",  # Dr. B. R. Ambedkar's Jayanti
+                "2018-08-02",  # Dadra and Nagar Haveli Liberation Day
+                "2018-12-19",  # Daman and Diu Liberation Day
+            ),
             "DL": ("2018-11-13",),
             "GA": (
                 "2018-04-14",
@@ -552,6 +557,7 @@ class TestIndia(CommonCountryTests, TestCase):
             ("2018-05-16", "Sikkim State Day"),
             ("2018-06-02", "Telangana Formation Day"),
             ("2018-06-16", "Id-ul-Fitr; Maharana Pratap Jayanti"),
+            ("2018-08-02", "Dadra and Nagar Haveli Liberation Day"),
             ("2018-08-15", "Independence Day"),
             ("2018-08-16", "Puducherry De Jure Transfer Day"),
             ("2018-08-22", "Bakrid"),
@@ -585,7 +591,7 @@ class TestIndia(CommonCountryTests, TestCase):
             ("2018-11-23", "Guru Nanak Jayanti"),
             ("2018-12-01", "Nagaland State Inauguration Day"),
             ("2018-12-02", "Assam Day"),
-            ("2018-12-19", "Goa Liberation Day"),
+            ("2018-12-19", "Daman and Diu Liberation Day; Goa Liberation Day"),
             ("2018-12-25", "Christmas"),
         )
 
@@ -616,6 +622,7 @@ class TestIndia(CommonCountryTests, TestCase):
             ("2018-05-16", "સિક્કિમ રાજ્ય દિવસ"),
             ("2018-06-02", "તેલંગાણા સ્થાપના દિવસ"),
             ("2018-06-16", "ઈદ-ઉલ-ફિત્ર; મહારાણા પ્રતાપ જયંતિ"),
+            ("2018-08-02", "દાદરા અને નગર હવેલી મુક્તિ દિવસ"),
             ("2018-08-15", "સ્વતંત્રતા દિવસ"),
             ("2018-08-16", "પુડુચેરી ડી જ્યુર ટ્રાન્સફર દિવસ"),
             ("2018-08-22", "બકરી ઈદ"),
@@ -647,7 +654,7 @@ class TestIndia(CommonCountryTests, TestCase):
             ("2018-11-23", "ગુરુ નાનક જયંતિ"),
             ("2018-12-01", "નાગાલેન્ડ રાજ્ય ઉદ્ઘાટન દિવસ"),
             ("2018-12-02", "આસામ દિવસ"),
-            ("2018-12-19", "ગોવા મુક્તિ દિવસ"),
+            ("2018-12-19", "ગોવા મુક્તિ દિવસ; દમણ અને દીવ મુક્તિ દિવસ"),
             ("2018-12-25", "નાતાલ"),
         )
 
@@ -678,6 +685,7 @@ class TestIndia(CommonCountryTests, TestCase):
             ("2018-05-16", "सिक्किम राज्य दिवस"),
             ("2018-06-02", "तेलंगाना स्थापना दिवस"),
             ("2018-06-16", "ईद-उल-फितर; महाराणा प्रताप जयंती"),
+            ("2018-08-02", "दादरा और नगर हवेली मुक्ति दिवस"),
             ("2018-08-15", "स्वतंत्रता दिवस"),
             ("2018-08-16", "पुडुचेरी डी ज्यूर स्थानांतरण दिवस"),
             ("2018-08-22", "बकरीद"),
@@ -709,7 +717,7 @@ class TestIndia(CommonCountryTests, TestCase):
             ("2018-11-23", "गुरु नानक जयंती"),
             ("2018-12-01", "नागालैंड राज्य उद्घाटन दिवस"),
             ("2018-12-02", "असम दिवस"),
-            ("2018-12-19", "गोवा मुक्ति दिवस"),
+            ("2018-12-19", "गोवा मुक्ति दिवस; दमन और दीव मुक्ति दिवस"),
             ("2018-12-25", "क्रिसमस"),
         )
 
@@ -743,6 +751,7 @@ class TestIndia(CommonCountryTests, TestCase):
             ("2018-05-16", "Sikkim State Day"),
             ("2018-06-02", "Telangana Formation Day"),
             ("2018-06-16", "Eid al-Fitr; Maharana Pratap Jayanti"),
+            ("2018-08-02", "Dadra and Nagar Haveli Liberation Day"),
             ("2018-08-15", "Independence Day"),
             ("2018-08-16", "Puducherry De Jure Transfer Day"),
             ("2018-08-22", "Eid al-Adha"),
@@ -776,7 +785,7 @@ class TestIndia(CommonCountryTests, TestCase):
             ("2018-11-23", "Guru Nanak Jayanti"),
             ("2018-12-01", "Nagaland State Inauguration Day"),
             ("2018-12-02", "Assam Day"),
-            ("2018-12-19", "Goa Liberation Day"),
+            ("2018-12-19", "Daman and Diu Liberation Day; Goa Liberation Day"),
             ("2018-12-25", "Christmas"),
         )
 


### PR DESCRIPTION
## Proposed change

This PR adds support for the merged Union Territory of **Dadra and Nagar Haveli and Daman and Diu** (ISO code `DH`).

**Changes included:**
* Added `_populate_subdiv_dh_public_holidays` to the `India` class.
* Added the following specific holidays:
    * **August 2:** Dadra and Nagar Haveli Liberation Day.
    * **December 19:** Daman and Diu Liberation Day.
* Added `DD` (Daman and Diu) as a deprecated alias pointing to `DH`.
* Added comprehensive tests for the year 2018 (verifying dates and localized names).
* Updated `hi` (Hindi) and `gu` (Gujarati) translation files (`.po`) and regenerated `.mo` files to support the new localized holiday names.

*Note: `make check` flagged issues in unrelated files (`sweden.py`, `south_korea.py`), but all India-specific tests passed successfully.*

## Type of change

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.