### PR TITLE
Update Chile holidays: restore bank holiday Dec 31

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -48,6 +48,7 @@ Eldar Mustafayev
 Emmanuel Arias
 Eugenio Panadero Maciá
 Fabian Affolter
+Federico Brunner
 Felix Lee
 Filip Bednárik
 Firas Kafri

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -62,6 +62,7 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         * [Law 21.521 (eliminate Dec 31 again, after the CMF publishes a specific regulation)](https://web.archive.org/web/20240214154900/https://www.bcn.cl/leychile/navegar?idNorma=1187323&idVersion=2023-02-03)
         * [Norma de Carácter General N° 543 de la CMF](https://web.archive.org/web/20250811111649/https://www.cmfchile.cl/normativa/ncg_543_2025.pdf)
         * [Resolución Exenta N° 7.671 (CMF, 2025-08-01)](https://web.archive.org/web/20250811123908/https://www.cmfchile.cl/sitio/aplic/serdoc/ver_sgd.php?s567=ba5ad42feea3531a678a9db5253a9477VFdwQmVVNVVRVFJOUkZWNlRucEpORTVCUFQwPQ==&secuencia=-1&t=1754086087)
+        * [Law 21.791 (restore bank holiday on Dec 31)](https://web.archive.org/web/20251219021727/https://www.bcn.cl/leychile/navegar?idNorma=1219578&idVersion=2025-12-17)
     """
 
     country = "CL"
@@ -244,7 +245,7 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         if 1957 <= self._year <= 1975:
             self._add_holiday_jun_30(name)
 
-        if 1956 <= self._year <= 2024 and self._year != 1997:
+        if 1956 <= self._year and self._year != 1997:
             self._add_holiday_dec_31(name)
 
     @property

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -60,8 +60,6 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         * [Law 19.973 (Sep 17, 2004 holiday)](https://web.archive.org/web/20250812023003/https://www.bcn.cl/leychile/navegar?idLey=19973)
         * [Law 20.450 (Sep 17, 2010 and Sep 20, 2010 holidays)](https://web.archive.org/web/20250812023308/https://www.bcn.cl/leychile/navegar?idLey=20450)
         * [Law 21.521 (eliminate Dec 31 again, after the CMF publishes a specific regulation)](https://web.archive.org/web/20240214154900/https://www.bcn.cl/leychile/navegar?idNorma=1187323&idVersion=2023-02-03)
-        * [Norma de Carácter General N° 543 de la CMF](https://web.archive.org/web/20250811111649/https://www.cmfchile.cl/normativa/ncg_543_2025.pdf)
-        * [Resolución Exenta N° 7.671 (CMF, 2025-08-01)](https://web.archive.org/web/20250811123908/https://www.cmfchile.cl/sitio/aplic/serdoc/ver_sgd.php?s567=ba5ad42feea3531a678a9db5253a9477VFdwQmVVNVVRVFJOUkZWNlRucEpORTVCUFQwPQ==&secuencia=-1&t=1754086087)
         * [Law 21.791 (restore bank holiday on Dec 31)](https://web.archive.org/web/20251219021727/https://www.bcn.cl/leychile/navegar?idNorma=1219578&idVersion=2025-12-17)
     """
 

--- a/tests/countries/test_chile.py
+++ b/tests/countries/test_chile.py
@@ -301,11 +301,9 @@ class TestChile(CommonCountryTests, TestCase):
         self.assertNoHolidayName(name)
         self.assertBankHolidayName(name, (f"{year}-06-30" for year in range(1957, 1976)))
         self.assertBankHolidayName(
-            name, (f"{year}-12-31" for year in (*range(1956, 1997), *range(1998, 2025)))
+            name, (f"{year}-12-31" for year in (*range(1956, 1997), *range(1998, self.end_year)))
         )
-        self.assertNoBankHolidayName(
-            name, range(self.start_year, 1956), 1997, range(2025, self.end_year)
-        )
+        self.assertNoBankHolidayName(name, range(self.start_year, 1956), 1997)
 
     def test_2019(self):
         self.assertHolidayDatesInYear(


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Restore Chile's bank holiday for December 31. This bank holiday had been removed earlier this year but has now been reinstated following the publication of [Law 21.791](https://www.bcn.cl/leychile/navegar?idNorma=1219578&idVersion=2025-12-17) on December 17, 2025.

Changes included:
- `holidays/countries/chile.py`: update method `_populate_bank_holidays` to include Dec 31 as a bank holiday and add the link to the official law in the References section
- `tests/countries/test_chile.py`: update method `test_bank_holidays` to test that Dec 31 is a bank holiday
- `CONTRIBUTORS`: added myself :)

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
