### PR TITLE
docs: add reusable Python example to generate .ics files for any country

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -563,3 +563,44 @@ To export to `.ics` format, use `save_ics`.
 
 For advanced features and customization of the exported `.ics` output, consider using
 the [icalendar](https://github.com/collective/icalendar) package.
+
+
+
+
+
+## Generate iCalendar (.ics) files for any country
+
+This example demonstrates how to generate `.ics` calendar files for any supported
+country using the `holidays` library by changing the country code and parameters.
+
+```python
+from holidays import country_holidays
+from holidays.ical import ICalExporter
+from pathlib import Path
+
+
+def generate_ics(country_code, years, language=None, output_dir=None):
+    """
+    Generate an .ics holiday calendar for a given country.
+
+    :param country_code: ISO country code (e.g. "US", "IN", "DE")
+    :param years: iterable of years (e.g. range(2024, 2026))
+    :param language: optional language code (e.g. "en", "fr")
+    :param output_dir: directory where the .ics file will be saved
+    """
+    holidays = country_holidays(
+        country_code,
+        years=years,
+        language=language,
+    )
+
+    output_dir = Path(output_dir or ".")
+    filename = output_dir / f"{country_code.upper()}_holidays.ics"
+
+    ICalExporter(holidays).save_ics(filename)
+    print(f"Saved calendar to {filename}")
+
+
+# Example usage
+if __name__ == "__main__":
+    generate_ics("US", years=range(2024, 2026), language="en")

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -568,12 +568,6 @@ the [icalendar](https://github.com/collective/icalendar) package.
 
 
 
-## Generate iCalendar (.ics) files for any country
-
-This example demonstrates how to generate `.ics` calendar files for any supported
-country using the `holidays` library by changing the country code and parameters.
-
-```python
 from holidays import country_holidays
 from holidays.ical import ICalExporter
 from pathlib import Path
@@ -588,6 +582,12 @@ def generate_ics(country_code, years, language=None, output_dir=None):
     :param language: optional language code (e.g. "en", "fr")
     :param output_dir: directory where the .ics file will be saved
     """
+
+    # Print a helpful message if country code is missing
+    if not country_code:
+        print("You need to provide a country code, e.g.: 'US', 'IN', 'DE'")
+        return
+
     holidays = country_holidays(
         country_code,
         years=years,


### PR DESCRIPTION
## Proposed change

This PR adds a reusable Python example to the documentation that demonstrates
how to generate `.ics` iCalendar files for any supported country using the
`holidays` library.

Instead of maintaining country-specific scripts, the example shows how to:
- Change the country code
- Specify a year range
- Optionally set the language

This keeps the documentation simple, generic, and easier to maintain.

Closes #3189.

## Type of change

- [x] Existing code/documentation/test/process quality improvement
