### PR TITLE
Update Australia holidays: add Queensland's Christmas Eve `HALF_DAY` holidays from 2019 onwards

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -155,6 +155,7 @@ Shaurya Uppal
 Sho Hirose
 Shreyansh Pande
 Shreyas Smarth
+Simon Green
 Simon Gurcke
 Sindhura Kumbakonam Subramanian
 Sugato Ray

--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -532,6 +532,14 @@ class Australia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         elif self._year >= 1984:
             self._move_holiday(dt, rule=SUN_TO_NEXT_MON, show_observed_label=False)
 
+    def _populate_subdiv_qld_half_day_holidays(self):
+        if self._year >= 2019:
+            # %s (from 6pm).
+            begin_time_label = self.tr("%s (from 6pm)")
+
+            # Christmas Eve.
+            self._add_christmas_eve(begin_time_label % self.tr("Christmas Eve"))
+
     def _populate_subdiv_sa_public_holidays(self):
         # New Year's Day.
         # 1984-2003: SAT, SUN - move to MON.

--- a/holidays/locale/en_AU/LC_MESSAGES/AU.po
+++ b/holidays/locale/en_AU/LC_MESSAGES/AU.po
@@ -14,9 +14,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.57\n"
+"Project-Id-Version: Holidays 0.89\n"
 "POT-Creation-Date: 2024-09-05 12:21+0700\n"
-"PO-Revision-Date: 2024-09-05 12:28+0700\n"
+"PO-Revision-Date: 2026-01-14 04:15+0000\n"
 "Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: en_AU\n"
@@ -123,6 +123,11 @@ msgstr ""
 
 #. The Royal Queensland Show.
 msgid "The Royal Queensland Show"
+msgstr ""
+
+#. %s (from 6pm).
+#, c-format
+msgid "%s (from 6pm)"
 msgstr ""
 
 #. Adelaide Cup Day.

--- a/holidays/locale/en_US/LC_MESSAGES/AU.po
+++ b/holidays/locale/en_US/LC_MESSAGES/AU.po
@@ -14,9 +14,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.57\n"
+"Project-Id-Version: Holidays 0.89\n"
 "POT-Creation-Date: 2024-09-05 12:21+0700\n"
-"PO-Revision-Date: 2024-09-05 12:30+0700\n"
+"PO-Revision-Date: 2026-01-14 04:15+0000\n"
 "Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: en_US\n"
@@ -124,6 +124,11 @@ msgstr "New Year's Eve"
 #. The Royal Queensland Show.
 msgid "The Royal Queensland Show"
 msgstr "The Royal Queensland Show"
+
+#. %s (from 6pm).
+#, c-format
+msgid "%s (from 6pm)"
+msgstr "%s (from 6pm)"
 
 #. Adelaide Cup Day.
 msgid "Adelaide Cup Day"

--- a/holidays/locale/th/LC_MESSAGES/AU.po
+++ b/holidays/locale/th/LC_MESSAGES/AU.po
@@ -14,9 +14,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.57\n"
+"Project-Id-Version: Holidays 0.89\n"
 "POT-Creation-Date: 2024-09-05 12:21+0700\n"
-"PO-Revision-Date: 2024-09-05 12:31+0700\n"
+"PO-Revision-Date: 2026-01-14 04:15+0000\n"
 "Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: th\n"
@@ -124,6 +124,11 @@ msgstr "วันสิ้นปี"
 #. The Royal Queensland Show.
 msgid "The Royal Queensland Show"
 msgstr "เทศกาลรอยัลควีนส์แลนด์โชว์"
+
+#. %s (from 6pm).
+#, c-format
+msgid "%s (from 6pm)"
+msgstr "%s (ตั้งแต่ 18:00 น.)"
 
 #. Adelaide Cup Day.
 msgid "Adelaide Cup Day"

--- a/tests/countries/test_australia.py
+++ b/tests/countries/test_australia.py
@@ -467,6 +467,24 @@ class TestAustralia(CommonCountryTests, TestCase):
         self.assertNoSubdivQldNonObservedHoliday("2010-12-28", "2011-01-03")
         self.assertSubdivWaHoliday("2011-04-26")
 
+    def test_christmas_eve(self):
+        for subdiv, name, start_year in (
+            ("NT", "Christmas Eve (from 7pm)", 2016),
+            ("QLD", "Christmas Eve (from 6pm)", 2019),
+            ("SA", "Christmas Eve (from 7pm)", 2012),
+        ):
+            self.assertNoHolidayName(name)
+            self.assertHalfDayHolidayName(
+                name,
+                self.subdiv_half_day_holidays[subdiv],
+                (f"{year}-12-24" for year in range(start_year, self.end_year)),
+            )
+            self.assertNoHalfDayHolidayName(
+                name,
+                self.subdiv_half_day_holidays[subdiv],
+                (f"{year}-12-24" for year in range(self.start_year, start_year)),
+            )
+
     def test_all_holidays(self):
         holidays_found = set()
         for subdiv in Australia.subdivisions:
@@ -508,6 +526,7 @@ class TestAustralia(CommonCountryTests, TestCase):
             "Christmas Day",
             "Proclamation Day",
             "Boxing Day",
+            "Christmas Eve (from 6pm)",
             "Christmas Eve (from 7pm)",
             "New Year's Eve (from 7pm)",
         }
@@ -701,7 +720,7 @@ class TestAustralia(CommonCountryTests, TestCase):
             ("2022-09-26", "Queen's Birthday"),
             ("2022-10-03", "Labour Day; Queen's Birthday"),
             ("2022-11-01", "Melbourne Cup Day"),
-            ("2022-12-24", "Christmas Eve (from 7pm)"),
+            ("2022-12-24", "Christmas Eve (from 6pm); Christmas Eve (from 7pm)"),
             ("2022-12-25", "Christmas Day"),
             ("2022-12-26", "Boxing Day; Christmas Day (observed); Proclamation Day"),
             (
@@ -736,7 +755,7 @@ class TestAustralia(CommonCountryTests, TestCase):
             ("2022-09-26", "Queen's Birthday"),
             ("2022-10-03", "Labor Day; Queen's Birthday"),
             ("2022-11-01", "Melbourne Cup Day"),
-            ("2022-12-24", "Christmas Eve (from 7pm)"),
+            ("2022-12-24", "Christmas Eve (from 6pm); Christmas Eve (from 7pm)"),
             ("2022-12-25", "Christmas Day"),
             ("2022-12-26", "Boxing Day; Christmas Day (observed); Proclamation Day"),
             (
@@ -771,7 +790,7 @@ class TestAustralia(CommonCountryTests, TestCase):
             ("2022-09-26", "วันเฉลิมพระชนมพรรษาสมเด็จพระราชินีนาถ"),
             ("2022-10-03", "วันเฉลิมพระชนมพรรษาสมเด็จพระราชินีนาถ; วันแรงงาน"),
             ("2022-11-01", "วันเมลเบิร์นคัพ"),
-            ("2022-12-24", "วันคริสต์มาสอีฟ (ตั้งแต่ 19:00 น.)"),
+            ("2022-12-24", "วันคริสต์มาสอีฟ (ตั้งแต่ 18:00 น.); วันคริสต์มาสอีฟ (ตั้งแต่ 19:00 น.)"),
             ("2022-12-25", "วันคริสต์มาส"),
             ("2022-12-26", "ชดเชยวันคริสต์มาส; วันสถาปนา; วันเปิดกล่องของขวัญ"),
             ("2022-12-27", "ชดเชยวันคริสต์มาส; ชดเชยวันสถาปนา; ชดเชยวันเปิดกล่องของขวัญ; วันเปิดกล่องของขวัญ"),


### PR DESCRIPTION
## Proposed change

 * Add a "half day" holiday for the sub-division of Queensland for Xmas Eve in Australia
 * Add tests for this, as well as the sub-divisions of SA and NT.

Your PR description goes here.

## Type of change

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.
