### PR TITLE
Update Australia holidays: move Anzac Day in 2026 (ACT)

### DIFF
--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -34,6 +34,7 @@ class Australia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
           * <https://web.archive.org/web/20250414072303/https://www.qld.gov.au/recreation/travel/holidays>
           * [ACT Holidays Act 1958](https://web.archive.org/web/20250322061953/https://www.legislation.act.gov.au/a/1958-19/)
           * [ACT 2013-2023](https://web.archive.org/web/20240401072340/https://www.cmtedd.act.gov.au/archived-content/holidays/previous-years)
+          * [ACT Holidays (Anzac Day 2026) Declaration 2025 (No 1)](https://legislation.act.gov.au/View/ni/2025-650/current/html/2025-650.html)
           * [NSW Banks and Bank Holidays Act 1912](https://web.archive.org/web/20241107225523/https://legislation.nsw.gov.au/view/html/repealed/current/act-1912-043)
           * [NSW Public Holidays Act 2010](https://web.archive.org/web/20250316173922/https://legislation.nsw.gov.au/view/html/inforce/current/act-2010-115)
           * [NT Public Holidays Act 1981](https://web.archive.org/web/20250315072128/https://legislation.nt.gov.au/api/sitecore/Act/PDF?id=12145)
@@ -189,11 +190,14 @@ class Australia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
 
         # ANZAC Day.
         # from 1959: SUN - move to MON.
+        # in 2026: move to MON.
 
         if self._year >= 1921:
             # ANZAC Day.
             dt = self._add_anzac_day(tr("ANZAC Day"))
-            if self._year >= 1959:
+            if self._year == 2026:
+                self._move_holiday(dt, rule=SAT_SUN_TO_NEXT_MON, show_observed_label=False)
+            elif self._year >= 1959:
                 self._move_holiday(dt, rule=SUN_TO_NEXT_MON, show_observed_label=False)
 
         # Easter Saturday.

--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -34,7 +34,7 @@ class Australia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
           * <https://web.archive.org/web/20250414072303/https://www.qld.gov.au/recreation/travel/holidays>
           * [ACT Holidays Act 1958](https://web.archive.org/web/20250322061953/https://www.legislation.act.gov.au/a/1958-19/)
           * [ACT 2013-2023](https://web.archive.org/web/20240401072340/https://www.cmtedd.act.gov.au/archived-content/holidays/previous-years)
-          * [ACT Holidays (Anzac Day 2026) Declaration 2025 (No 1)](https://legislation.act.gov.au/View/ni/2025-650/current/html/2025-650.html)
+          * [ACT Holidays (Anzac Day 2026) Declaration 2025 (No 1)](https://web.archive.org/web/20260116225801/https://legislation.act.gov.au/View/ni/2025-650/current/html/2025-650.html)
           * [NSW Banks and Bank Holidays Act 1912](https://web.archive.org/web/20241107225523/https://legislation.nsw.gov.au/view/html/repealed/current/act-1912-043)
           * [NSW Public Holidays Act 2010](https://web.archive.org/web/20250316173922/https://legislation.nsw.gov.au/view/html/inforce/current/act-2010-115)
           * [NT Public Holidays Act 1981](https://web.archive.org/web/20250315072128/https://legislation.nt.gov.au/api/sitecore/Act/PDF?id=12145)

--- a/tests/countries/test_australia.py
+++ b/tests/countries/test_australia.py
@@ -143,9 +143,13 @@ class TestAustralia(CommonCountryTests, TestCase):
         name = "ANZAC Day"
         self.assertHolidayName(name, (f"{year}-04-25" for year in range(1921, self.end_year)))
         self.assertNoHolidayName(name, range(self.start_year, 1921))
-        for holidays in self.subdiv_holidays.values():
+        for subdiv, holidays in self.subdiv_holidays.items():
             self.assertHolidayName(name, holidays, range(1921, self.end_year))
             self.assertNoHolidayName(name, holidays, range(self.start_year, 1921))
+
+            if subdiv == "ACT":
+                self.assertNoHolidayName(name, holidays, "2026-04-25")
+                self.assertHolidayName(name, holidays, "2026-04-27")
 
     def test_labor_day(self):
         name = "Labour Day"


### PR DESCRIPTION
## Proposed change

ACT (a territory of Australia) passed a law on 28/11/2025 that changed the date of Anzac Day in 2026 (only). This PR follows the change, and adds a check for it.

## Type of change

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.
