### PR TITLE
Add test ensuring no duplicate holiday dates across a year

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -73,6 +73,25 @@ class TestCountryHolidays(unittest.TestCase):
             CountryHoliday("IT")
         self.assertIn("CountryHoliday is deprecated", str(ctx.warning))
 
+class TestNoDuplicateDatesAcrossYears(unittest.TestCase):
+    """Ensure no duplicate holiday dates are produced when multiple years are requested."""
+
+    @pytest.mark.skipif(
+        PYTHON_VERSION != PYTHON_LATEST_SUPPORTED_VERSION,
+        reason="Run once on the latest Python version only",
+    )
+    @mock.patch("pathlib.Path.rglob", return_value=())
+    def test_no_duplicate_dates_across_years(self, _unused_mock):
+        years = {2020, 2021}
+
+        holidays = country_holidays("US", years=years)
+        dates = [dt for dt in holidays if isinstance(dt, date)]
+
+        self.assertEqual(
+            len(dates),
+            len(set(dates)),
+            "Duplicate holiday dates detected across multiple years",
+        )
 
 class TestFinancialHolidays(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Proposed change

This PR adds a logic-level test asserting that requesting holidays across
multiple years does not produce duplicate date entries.

The test protects against subtle aggregation or caching regressions when
holiday data is generated per-year and merged into a single result.
No runtime behavior is changed.

## Type of change

- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)

## Checklist

- [x] I've read and followed the contributing guidelines.
- [x] I've run the relevant tests locally; all checks and tests passed.
