### PR TITLE
Update Germany holidays: add catholic holidays to Augsburg

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -56,6 +56,7 @@ Filip Bednárik
 Firas Kafri
 Gabriel L Martinez
 Gabriel Trabanco
+Gerhard Schmidt
 Giedrius Mauza
 Gordon Inggs
 Greg Rafferty

--- a/holidays/countries/germany.py
+++ b/holidays/countries/germany.py
@@ -266,6 +266,7 @@ class Germany(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolid
 
     def _populate_subdiv_augsburg_public_holidays(self):
         self._populate_subdiv_by_public_holidays()
+        self._populate_subdiv_by_catholic_holidays()
 
         # Augsburg Peace Festival.
         self._add_holiday_aug_8(tr("Augsburger Hohes Friedensfest"))

--- a/holidays/countries/germany.py
+++ b/holidays/countries/germany.py
@@ -266,7 +266,9 @@ class Germany(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolid
 
     def _populate_subdiv_augsburg_public_holidays(self):
         self._populate_subdiv_by_public_holidays()
-        self._populate_subdiv_by_catholic_holidays()
+
+        # Assumption Day.
+        self._add_assumption_of_mary_day(tr("Mariä Himmelfahrt"))
 
         # Augsburg Peace Festival.
         self._add_holiday_aug_8(tr("Augsburger Hohes Friedensfest"))

--- a/tests/countries/test_germany.py
+++ b/tests/countries/test_germany.py
@@ -232,7 +232,7 @@ class TestGermany(CommonCountryTests, TestCase):
         self.assertNoHolidayName(name)
         for subdiv, holidays in self.subdiv_holidays.items():
             # Saarland.
-            if subdiv == "SL":
+            if subdiv in ("SL", "Augsburg"):
                 self.assertHolidayName(
                     name, holidays, (f"{year}-08-15" for year in self.full_range)
                 )

--- a/tests/countries/test_germany.py
+++ b/tests/countries/test_germany.py
@@ -232,7 +232,7 @@ class TestGermany(CommonCountryTests, TestCase):
         self.assertNoHolidayName(name)
         for subdiv, holidays in self.subdiv_holidays.items():
             # Saarland.
-            if subdiv in ("SL", "Augsburg"):
+            if subdiv in {"SL", "Augsburg"}:
                 self.assertHolidayName(
                     name, holidays, (f"{year}-08-15" for year in self.full_range)
                 )


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

There is a special subdivision for the city Augsburg. Augsburg is a catholic city. Therefore all Bavarian holidays for predominantly catholic regions must also be applied. 

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
