### PR TITLE
Add generic vacanza.py script for exporting holiday calendars

### DIFF
--- a/docs/examples/vacanza.py
+++ b/docs/examples/vacanza.py
@@ -37,8 +37,7 @@ def export_holiday_calendars(
 
             
 
-        except Exception as error:
-            
+        except Exception:
             continue
 
 if __name__ == "__main__":

--- a/docs/examples/vacanza.py
+++ b/docs/examples/vacanza.py
@@ -1,0 +1,53 @@
+from holidays.ical import ICalExporter
+
+
+def export_holiday_calendars(
+    country_class,
+    country_code,
+    years,
+    categories,
+    language=None,
+    output_dir="."
+):
+    """
+    Export holiday calendars as .ics files for each category.
+    """
+
+    for category in categories:
+        try:
+            holidays_obj = country_class(
+                years=years,
+                categories=category,
+                language=language,
+            )
+            # Note: include_sundays is not supported in all holidays versions
+
+
+            # Prepare year label
+            if isinstance(years, range):
+                year_label = f"{years.start}_{years.stop - 1}"
+            else:
+                year_label = "_".join(map(str, years))
+
+            file_name = f"{country_code}_{category.upper()}_{year_label}.ics"
+            file_path = f"{output_dir}/{file_name}"
+
+            exporter = ICalExporter(holidays_obj)
+            exporter.save_ics(file_path)
+
+            print(f"Generated: {file_name}")
+
+        except Exception as error:
+            print(f"Failed for category '{category}': {error}")
+            continue
+
+if __name__ == "__main__":
+    from holidays.countries import US
+
+export_holiday_calendars(
+    country_class=US,
+    country_code="US",
+    years=range(2025, 2026),
+    categories=US.supported_categories,
+    language="en"
+)

--- a/docs/examples/vacanza.py
+++ b/docs/examples/vacanza.py
@@ -35,10 +35,10 @@ def export_holiday_calendars(
             exporter = ICalExporter(holidays_obj)
             exporter.save_ics(file_path)
 
-            print(f"Generated: {file_name}")
+            
 
         except Exception as error:
-            print(f"Failed for category '{category}': {error}")
+            
             continue
 
 if __name__ == "__main__":

--- a/docs/examples/vacanza.py
+++ b/docs/examples/vacanza.py
@@ -2,12 +2,7 @@ from holidays.ical import ICalExporter
 
 
 def export_holiday_calendars(
-    country_class,
-    country_code,
-    years,
-    categories,
-    language=None,
-    output_dir="."
+    country_class, country_code, years, categories, language=None, output_dir="."
 ):
     """
     Export holiday calendars as .ics files for each category.
@@ -48,5 +43,5 @@ export_holiday_calendars(
     country_code="US",
     years=range(2025, 2026),
     categories=US.supported_categories,
-    language="en"
+    language="en",
 )


### PR DESCRIPTION
## Proposed change

This PR adds a generic example script 'vacanza.py' under the 'examples' directory.

The script demonstrates how to:
- Generate holiday calendars dynamically for a given country
- Export '.ics' files for each supported holiday category
- Reuse the existing 'ICalExporter' functionality

This serves as a reusable helper for future CLI or automation workflows.

My PR link : https://github.com/vacanza/holidays/pull/3257

## Type of change

-[x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)


## Checklist

- [ ] I've read and followed the contributing guidelines(https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [ ] I've run 'make check' locally; all checks and tests passed.




