### PR TITLE
Update Ireland holidays: add `OPTIONAL` category

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -96,6 +96,7 @@ Laurent Comparet
 Lucca Augusto
 Maina Kamau
 Malthe Borch
+Manish Tiwari
 Marek Šuppa
 Martin Becker
 Martin Thurau
@@ -108,7 +109,6 @@ Mike Borsetti
 Mike Polyakovsky
 Miroslav Šedivý
 Monde Sinxi
-Manish Tiwari
 Nalin Gupta
 Nataliia Dmytriievska
 Nate Harris

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -108,6 +108,7 @@ Mike Borsetti
 Mike Polyakovsky
 Miroslav Šedivý
 Monde Sinxi
+Manish Tiwari
 Nalin Gupta
 Nataliia Dmytriievska
 Nate Harris

--- a/README.md
+++ b/README.md
@@ -887,7 +887,7 @@ any) in brackets, available languages and additional holiday categories. All cou
 <td>IE</td>
 <td></td>
 <td></td>
-<td></td>
+<td>OPTIONAL</td>
 </tr>
 <tr>
 <td>Isle of Man</td>

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -29,24 +29,6 @@ class Ireland(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolid
     start_year = 1872
 
     def __init__(self, *args, **kwargs):
-        self.include_good_friday = kwargs.pop("include_good_friday", False)
-
-        # Backward compatibility for the legacy `include_good_friday` flag.
-        # Good Friday now belongs to the OPTIONAL category, but if the flag is
-        # used we automatically enable OPTIONAL alongside the default category.
-        if self.include_good_friday:
-            categories = kwargs.get("categories")
-            if categories is None:
-                kwargs["categories"] = (PUBLIC, OPTIONAL)
-            else:
-                if isinstance(categories, str):
-                    categories = {categories}
-                else:
-                    categories = set(categories)
-                categories.add(OPTIONAL)
-                kwargs["categories"] = tuple(categories)
-
-        kwargs.setdefault("observed", False)
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, IrelandStaticHolidays)

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -101,7 +101,7 @@ class Ireland(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolid
         self._add_christmas_day_two("Saint Stephen's Day")
 
     def _populate_optional_holidays(self):
-        # Good Friday (bank holiday, not an official public holiday).
+        # Good Friday.
         self._add_good_friday("Good Friday")
 
 

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -27,6 +27,8 @@ class Ireland(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolid
     start_year = 1872
 
     def __init__(self, *args, **kwargs):
+        self.include_good_friday=kwargs.pop("include_good_friday", False)
+        kwargs.setdefault("observed", False)
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, IrelandStaticHolidays)
@@ -79,6 +81,10 @@ class Ireland(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolid
 
         # Saint Stephen's Day.
         self._add_christmas_day_two("Saint Stephen's Day")
+
+        # Good Friday (optional, not a public holiday in Ireland but observed by banks)
+        if self.include_good_friday:
+            self._add_good_friday("Good Friday")
 
 
 class IE(Ireland):

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -27,7 +27,7 @@ class Ireland(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolid
     start_year = 1872
 
     def __init__(self, *args, **kwargs):
-        self.include_good_friday=kwargs.pop("include_good_friday", False)
+        self.include_good_friday = kwargs.pop("include_good_friday", False)
         kwargs.setdefault("observed", False)
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)

--- a/tests/countries/test_ireland.py
+++ b/tests/countries/test_ireland.py
@@ -176,4 +176,14 @@ class TestIreland(CommonCountryTests, TestCase):
         )
     def test_good_friday(self):
         name = "Good Friday"
-        self._assertHolidayName(name)
+        self.assertNoHolidayName(name)
+        self.assertOptionalHolidayName(
+            name,
+            "2020-04-10",
+            "2021-04-02",
+            "2022-04-15",
+            "2023-04-07",
+            "2024-03-29",
+            "2025-04-18",
+        )
+        self.assertOptionalHolidayName(name, self.full_range)

--- a/tests/countries/test_ireland.py
+++ b/tests/countries/test_ireland.py
@@ -56,6 +56,20 @@ class TestIreland(CommonCountryTests, TestCase):
         self.assertHolidayName(name, (f"{year}-03-17" for year in range(1903, self.end_year)))
         self.assertNoHolidayName(name, range(self.start_year, 1903))
 
+    def test_good_friday(self):
+        name = "Good Friday"
+        self.assertNoHolidayName(name)
+        self.assertOptionalHolidayName(
+            name,
+            "2020-04-10",
+            "2021-04-02",
+            "2022-04-15",
+            "2023-04-07",
+            "2024-03-29",
+            "2025-04-18",
+        )
+        self.assertOptionalHolidayName(name, self.full_range)
+        
     def test_easter_monday(self):
         name = "Easter Monday"
         self.assertHolidayName(
@@ -174,16 +188,3 @@ class TestIreland(CommonCountryTests, TestCase):
             ("2022-12-25", "Christmas Day"),
             ("2022-12-26", "Saint Stephen's Day"),
         )
-    def test_good_friday(self):
-        name = "Good Friday"
-        self.assertNoHolidayName(name)
-        self.assertOptionalHolidayName(
-            name,
-            "2020-04-10",
-            "2021-04-02",
-            "2022-04-15",
-            "2023-04-07",
-            "2024-03-29",
-            "2025-04-18",
-        )
-        self.assertOptionalHolidayName(name, self.full_range)

--- a/tests/countries/test_ireland.py
+++ b/tests/countries/test_ireland.py
@@ -69,7 +69,6 @@ class TestIreland(CommonCountryTests, TestCase):
             "2025-04-18",
         )
         self.assertOptionalHolidayName(name, self.full_range)
-        
     def test_easter_monday(self):
         name = "Easter Monday"
         self.assertHolidayName(

--- a/tests/countries/test_ireland.py
+++ b/tests/countries/test_ireland.py
@@ -174,3 +174,6 @@ class TestIreland(CommonCountryTests, TestCase):
             ("2022-12-25", "Christmas Day"),
             ("2022-12-26", "Saint Stephen's Day"),
         )
+    def test_good_friday(self):
+        name = "Good Friday"
+        self._assertHolidayName(name)

--- a/tests/countries/test_ireland.py
+++ b/tests/countries/test_ireland.py
@@ -69,6 +69,7 @@ class TestIreland(CommonCountryTests, TestCase):
             "2025-04-18",
         )
         self.assertOptionalHolidayName(name, self.full_range)
+
     def test_easter_monday(self):
         name = "Easter Monday"
         self.assertHolidayName(


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change
This PR adds optional Good Friday holiday support to the Ireland calendar via a new include_good_friday parameter. 
Fixes #3255 

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->
### While Good Friday is not an official public holiday in Ireland, it is widely observed by:
- Financial institutions and banks (banking holiday)
- Government offices
- Many businesses for operational purposes
- Stock exchange closures

This optional parameter allows users to include Good Friday for financial calculations, business day adjustments, and other use cases where it's relevant, while keeping the default behavior consistent with official public holiday listings that don't include Good Friday.


## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
