### PR TITLE
Update Australia holidays: add extra ANZAC Day holiday in NSW

### DIFF
--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -313,7 +313,7 @@ class Australia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         # ANZAC Day.
         # 1912-2010: SUN - add MON.
         # from 2011: normal.
-        # 2026-2027: SAT,SUN - add MON.
+        # 2026-2027: SAT, SUN - add MON.
 
         if self._year >= 1921:
             # ANZAC Day.

--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -37,6 +37,7 @@ class Australia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
           * [ACT Holidays (Anzac Day 2026) Declaration 2025 (No 1)](https://web.archive.org/web/20260116225801/https://legislation.act.gov.au/View/ni/2025-650/current/html/2025-650.html)
           * [NSW Banks and Bank Holidays Act 1912](https://web.archive.org/web/20241107225523/https://legislation.nsw.gov.au/view/html/repealed/current/act-1912-043)
           * [NSW Public Holidays Act 2010](https://web.archive.org/web/20250316173922/https://legislation.nsw.gov.au/view/html/inforce/current/act-2010-115)
+          * [NSW 2026-2027](https://web.archive.org/web/20260216073138/https://www.nsw.gov.au/about-nsw/public-holidays)
           * [NT Public Holidays Act 1981](https://web.archive.org/web/20250315072128/https://legislation.nt.gov.au/api/sitecore/Act/PDF?id=12145)
           * [QLD Holidays Act 1983](https://web.archive.org/web/20250404230918/https://www.legislation.qld.gov.au/view/html/inforce/current/act-1983-018)
           * [QLD 2013-2028](https://web.archive.org/web/20150703042947/http://www.qld.gov.au/recreation/travel/holidays/public/)

--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -313,12 +313,15 @@ class Australia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         # ANZAC Day.
         # 1912-2010: SUN - add MON.
         # from 2011: normal.
+        # 2026-2027: SAT,SUN - add MON.
 
         if self._year >= 1921:
             # ANZAC Day.
             dt = self._add_anzac_day(tr("ANZAC Day"))
             if self._year <= 2010:
                 self._add_observed(dt, rule=SUN_TO_NEXT_MON)
+            elif 2026 <= self._year <= 2027:
+                self._add_observed(dt, rule=SAT_SUN_TO_NEXT_MON)
 
         # Labor Day.
         self._add_holiday_1st_mon_of_oct(tr("Labour Day"))

--- a/tests/countries/test_australia.py
+++ b/tests/countries/test_australia.py
@@ -150,7 +150,7 @@ class TestAustralia(CommonCountryTests, TestCase):
             if subdiv == "ACT":
                 self.assertNoHolidayName(name, holidays, "2026-04-25")
                 self.assertHolidayName(name, holidays, "2026-04-27")
-            elif subdiv in ("NSW", "WA"):
+            elif subdiv in {"NSW", "WA"}:
                 self.assertHolidayName(name, holidays, "2026-04-25")
                 self.assertHolidayName(
                     f"{name} (observed)",

--- a/tests/countries/test_australia.py
+++ b/tests/countries/test_australia.py
@@ -141,6 +141,7 @@ class TestAustralia(CommonCountryTests, TestCase):
 
     def test_anzac_day(self):
         name = "ANZAC Day"
+        observed_name = "ANZAC Day (observed)"
         self.assertHolidayName(name, (f"{year}-04-25" for year in range(1921, self.end_year)))
         self.assertNoHolidayName(name, range(self.start_year, 1921))
         for subdiv, holidays in self.subdiv_holidays.items():
@@ -150,6 +151,9 @@ class TestAustralia(CommonCountryTests, TestCase):
             if subdiv == "ACT":
                 self.assertNoHolidayName(name, holidays, "2026-04-25")
                 self.assertHolidayName(name, holidays, "2026-04-27")
+            elif subdiv in ("NSW", "WA"):
+                self.assertHolidayName(name, holidays, "2026-04-25")
+                self.assertHolidayName(observed_name, holidays, "2026-04-27")
 
     def test_labor_day(self):
         name = "Labour Day"

--- a/tests/countries/test_australia.py
+++ b/tests/countries/test_australia.py
@@ -141,7 +141,6 @@ class TestAustralia(CommonCountryTests, TestCase):
 
     def test_anzac_day(self):
         name = "ANZAC Day"
-        observed_name = "ANZAC Day (observed)"
         self.assertHolidayName(name, (f"{year}-04-25" for year in range(1921, self.end_year)))
         self.assertNoHolidayName(name, range(self.start_year, 1921))
         for subdiv, holidays in self.subdiv_holidays.items():
@@ -153,7 +152,12 @@ class TestAustralia(CommonCountryTests, TestCase):
                 self.assertHolidayName(name, holidays, "2026-04-27")
             elif subdiv in ("NSW", "WA"):
                 self.assertHolidayName(name, holidays, "2026-04-25")
-                self.assertHolidayName(observed_name, holidays, "2026-04-27")
+                self.assertHolidayName(
+                    f"{name} (observed)",
+                    holidays,
+                    "2026-04-27",
+                    "2027-04-26",
+                )
 
     def test_labor_day(self):
         name = "Labour Day"


### PR DESCRIPTION
## Proposed change

Add an additional holiday for ANZAC Day in the NSW subdivision of Australia for the next two years only. The NSW government have [announced](https://www.abc.net.au/news/2026-02-15/nsw-minns-government-anzac-day-extra-public-holiday/106346332) that

> Mr Minns announced on Sunday the government would be making the Monday after Anzac Day a public holiday in 2026 and 2027 for residents in New South Wales. 

The legislative instrument has not yet been created. Given that the holiday is just over two months away, I thought it would be good to create a the PR now. Let me know if you want to wait until the necessary laws have actually passed parliament.

WBM: https://web.archive.org/web/20260215015505/https://www.abc.net.au/news/2026-02-15/nsw-minns-government-anzac-day-extra-public-holiday/106346332

## Type of change

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.
