### PR TITLE
Update l10n test: check .po files for mandatory metadata fields

### DIFF
--- a/tests/test_l10n.py
+++ b/tests/test_l10n.py
@@ -67,11 +67,11 @@ class TestLocalization(unittest.TestCase):
 
                 raise e
 
-            missing_fields = mandatory_fields - set(po_file.metadata.keys())
+            missing_fields = mandatory_fields - set(po_file.metadata)
             self.assertFalse(
                 missing_fields,
                 f"{po_path} metadata does not contain mandatory fields: "
-                f"{', '.join(missing_fields)}",
+                f"{', '.join(sorted(missing_fields))}",
             )
 
             # Collect `<country_code>` part from

--- a/tests/test_l10n.py
+++ b/tests/test_l10n.py
@@ -37,6 +37,21 @@ class TestLocalization(unittest.TestCase):
 
     def test_localization(self):
         locale_dir = Path(__file__).parents[1] / "holidays" / "locale"
+        placeholder_re = re.compile(r"%[a-zA-Z]")
+        mandatory_fields = {
+            "Project-Id-Version",
+            "Report-Msgid-Bugs-To",
+            "POT-Creation-Date",
+            "PO-Revision-Date",
+            "Last-Translator",
+            "Language-Team",
+            "Language",
+            "MIME-Version",
+            "Content-Type",
+            "Content-Transfer-Encoding",
+            "X-Source-Language",
+        }
+
         for po_path in sorted(locale_dir.rglob("*.po")):
             try:
                 po_file = create_po_file(po_path, check_for_duplicates=True)
@@ -52,19 +67,6 @@ class TestLocalization(unittest.TestCase):
 
                 raise e
 
-            mandatory_fields = {
-                "Content-Transfer-Encoding",
-                "Content-Type",
-                "Language-Team",
-                "Language",
-                "Last-Translator",
-                "MIME-Version",
-                "PO-Revision-Date",
-                "POT-Creation-Date",
-                "Project-Id-Version",
-                "Report-Msgid-Bugs-To",
-                "X-Source-Language",
-            }
             missing_fields = mandatory_fields - set(po_file.metadata.keys())
             self.assertFalse(
                 missing_fields,
@@ -101,7 +103,6 @@ class TestLocalization(unittest.TestCase):
                 f"{', '.join(oe.msgid for oe in obsolete_entries)}",
             )
 
-            placeholder_re = re.compile(r"%[a-zA-Z]")
             for entry in po_file:
                 self.assertEqual(
                     Counter(placeholder_re.findall(entry.msgid)),

--- a/tests/test_l10n.py
+++ b/tests/test_l10n.py
@@ -36,11 +36,23 @@ class TestLocalization(unittest.TestCase):
         self.assertEqual(pl_xx["2022-01-01"], "Nowy Rok")
 
     def test_localization(self):
-        tests_dir = Path(__file__).parent
-        locale_dir = tests_dir.parent / "holidays" / "locale"
+        locale_dir = Path(__file__).parents[1] / "holidays" / "locale"
         placeholder_re = re.compile(r"%[a-zA-Z]")
+        mandatory_fields = {
+            "Project-Id-Version",
+            "Report-Msgid-Bugs-To",
+            "POT-Creation-Date",
+            "PO-Revision-Date",
+            "Last-Translator",
+            "Language-Team",
+            "Language",
+            "MIME-Version",
+            "Content-Type",
+            "Content-Transfer-Encoding",
+            "X-Source-Language",
+        }
 
-        for po_path in sorted(Path(locale_dir).rglob("*.po")):
+        for po_path in sorted(locale_dir.rglob("*.po")):
             try:
                 po_file = create_po_file(po_path, check_for_duplicates=True)
             except ValueError as e:
@@ -54,6 +66,13 @@ class TestLocalization(unittest.TestCase):
                 )
 
                 raise e
+
+            missing_fields = mandatory_fields - set(po_file.metadata.keys())
+            self.assertFalse(
+                missing_fields,
+                f"{po_path} metadata does not contain mandatory fields: "
+                f"{', '.join(missing_fields)}",
+            )
 
             # Collect `<country_code>` part from
             # holidays/locale/<locale>/LC_MESSAGES/<country_code>.po.

--- a/tests/test_l10n.py
+++ b/tests/test_l10n.py
@@ -37,21 +37,6 @@ class TestLocalization(unittest.TestCase):
 
     def test_localization(self):
         locale_dir = Path(__file__).parents[1] / "holidays" / "locale"
-        placeholder_re = re.compile(r"%[a-zA-Z]")
-        mandatory_fields = {
-            "Project-Id-Version",
-            "Report-Msgid-Bugs-To",
-            "POT-Creation-Date",
-            "PO-Revision-Date",
-            "Last-Translator",
-            "Language-Team",
-            "Language",
-            "MIME-Version",
-            "Content-Type",
-            "Content-Transfer-Encoding",
-            "X-Source-Language",
-        }
-
         for po_path in sorted(locale_dir.rglob("*.po")):
             try:
                 po_file = create_po_file(po_path, check_for_duplicates=True)
@@ -67,6 +52,19 @@ class TestLocalization(unittest.TestCase):
 
                 raise e
 
+            mandatory_fields = {
+                "Content-Transfer-Encoding",
+                "Content-Type",
+                "Language-Team",
+                "Language",
+                "Last-Translator",
+                "MIME-Version",
+                "PO-Revision-Date",
+                "POT-Creation-Date",
+                "Project-Id-Version",
+                "Report-Msgid-Bugs-To",
+                "X-Source-Language",
+            }
             missing_fields = mandatory_fields - set(po_file.metadata.keys())
             self.assertFalse(
                 missing_fields,
@@ -103,6 +101,7 @@ class TestLocalization(unittest.TestCase):
                 f"{', '.join(oe.msgid for oe in obsolete_entries)}",
             )
 
+            placeholder_re = re.compile(r"%[a-zA-Z]")
             for entry in po_file:
                 self.assertEqual(
                     Counter(placeholder_re.findall(entry.msgid)),


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Update l10n test: check .po files for mandatory metadata fields.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
