### PR TITLE
Update South Korea holidays: add Constitution Day back for 2026 onwards

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -150,6 +150,7 @@ Saheel Sapovadia
 Sam Tregar
 Samman Sarkar
 Santiago Feliu
+Seong hun Cho
 Sergi Almacellas Abellana
 Sergio Mayoral Martinez
 Serhii Murza

--- a/holidays/countries/south_korea.py
+++ b/holidays/countries/south_korea.py
@@ -61,7 +61,8 @@ class SouthKorea(
     References:
         * <https://en.wikipedia.org/wiki/Public_holidays_in_South_Korea>
         * <https://web.archive.org/web/20240429121214/https://www.law.go.kr/법령/관공서의%20공휴일에%20관한%20규정>
-        * <https://web.archive.org/web/20260220070517/https://www.law.go.kr/LSW/lsInfoP.do?efYd=20220101&lsiSeq=233829>
+        * [Public Holidays Act (2026 Amendment)](http://archive.today/2026.02.20-080801/https://www.law.go.kr/LSW/lsInfoP.do?lsiSeq=283311&ancYd=20260210%230000)
+        * [National Day Act (2014 Amendment)](http://archive.today/2026.02.20-081906/https://www.law.go.kr/LSW//lsInfoP.do?lsiSeq=165523&ancYd=20141230%230000)
         * <https://web.archive.org/web/20250429081641/https://elaw.klri.re.kr/eng_service/lawView.do?lang=ENG&hseq=34678>
         * <https://web.archive.org/web/20250123212346/https://elaw.klri.re.kr/eng_service/%20lawView.do?hseq=38405&lang=ENG>
         * <https://namu.wiki/w/대통령%20선거일>

--- a/holidays/countries/south_korea.py
+++ b/holidays/countries/south_korea.py
@@ -61,6 +61,7 @@ class SouthKorea(
     References:
         * <https://en.wikipedia.org/wiki/Public_holidays_in_South_Korea>
         * <https://web.archive.org/web/20240429121214/https://www.law.go.kr/법령/관공서의%20공휴일에%20관한%20규정>
+        * <https://web.archive.org/web/20260220070517/https://www.law.go.kr/LSW/lsInfoP.do?efYd=20220101&lsiSeq=233829>
         * <https://web.archive.org/web/20250429081641/https://elaw.klri.re.kr/eng_service/lawView.do?lang=ENG&hseq=34678>
         * <https://web.archive.org/web/20250123212346/https://elaw.klri.re.kr/eng_service/%20lawView.do?hseq=38405&lang=ENG>
         * <https://namu.wiki/w/대통령%20선거일>
@@ -189,7 +190,7 @@ class SouthKorea(
             jun_6 = self._add_holiday_jun_6(tr("현충일"))
             # jun_6 is used later for Local Election Day.
 
-        if self._year <= 2007:
+        if self._year <= 2007 or self._year >= 2026:
             # Constitution Day.
             self._add_holiday_jul_17(tr("제헌절"))
 

--- a/tests/countries/test_south_korea.py
+++ b/tests/countries/test_south_korea.py
@@ -353,7 +353,8 @@ class TestSouthKorea(CommonCountryTests, TestCase):
     def test_constitution_day(self):
         name = "제헌절"
         self.assertHolidayName(name, (f"{year}-07-17" for year in range(self.start_year, 2008)))
-        self.assertNoHolidayName(name, range(2008, self.end_year))
+        self.assertNoHolidayName(name, range(2008, 2026))
+        self.assertHolidayName(name, (f"{year}-07-17" for year in range(2026, self.end_year)))
         self.assertHolidayName(f"{name} 대체 휴일", "1960-07-18")
 
     def test_liberation_day(self):

--- a/tests/countries/test_south_korea.py
+++ b/tests/countries/test_south_korea.py
@@ -352,9 +352,14 @@ class TestSouthKorea(CommonCountryTests, TestCase):
 
     def test_constitution_day(self):
         name = "제헌절"
-        self.assertHolidayName(name, (f"{year}-07-17" for year in range(self.start_year, 2008)))
+        self.assertHolidayName(
+            name,
+            (
+                f"{year}-07-17"
+                for year in (*range(self.start_year, 2008), *range(2026, self.end_year))
+            ),
+        )
         self.assertNoHolidayName(name, range(2008, 2026))
-        self.assertHolidayName(name, (f"{year}-07-17" for year in range(2026, self.end_year)))
         self.assertHolidayName(f"{name} 대체 휴일", "1960-07-18")
 
     def test_liberation_day(self):


### PR DESCRIPTION
## Proposed change

Restore Constitution Day (제헌절, July 17) as a public holiday in South Korea from 2026 onward.

Constitution Day was removed from the public holiday list in 2008 but has been reinstated per the Act on Public Holidays (공휴일에 관한 법률).

Reference: https://web.archive.org/web/20260220070517/https://www.law.go.kr/LSW/lsInfoP.do?efYd=20220101&lsiSeq=233829

## Type of change

- [x] Supported country/market holidays update (calendar discrepancy fix, localization)

## Checklist

- [x] I've read the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md)
- [x] I've run `make check` locally; all checks and tests passed