### PR TITLE
Refactor EntityLoader: add namespace validation

### DIFF
--- a/holidays/registry.py
+++ b/holidays/registry.py
@@ -318,6 +318,12 @@ class EntityLoader:
                 "`from holidays.financial import Entity`."
             )
 
+        if not path.startswith("holidays."):
+            raise ValueError(
+                f"Invalid entity path: {path}. "
+                "Entities must be in the holidays namespace."
+            )
+
         entity_path = path.split(".")
 
         self.entity = None

--- a/holidays/registry.py
+++ b/holidays/registry.py
@@ -308,16 +308,7 @@ class EntityLoader:
     __slots__ = ("entity", "entity_name", "module_name")
 
     def __init__(self, path: str, *args, **kwargs) -> None:
-        """
-        Set up a lazy loader.
-
-        :param path:
-            The path to the entity to be lazy-loaded.
-        :param args:
-            Additional arguments.
-        :param kwargs:
-            Additional keyword arguments.
-        """
+        """Set up a lazy loader."""
         if args:
             raise TypeError(
                 "This is a holidays entity loader class. "
@@ -325,12 +316,6 @@ class EntityLoader:
                 "want to derive from directly: e.g., "
                 "`from holidays.countries import Entity` or "
                 "`from holidays.financial import Entity`."
-            )
-
-        if not path.startswith("holidays."):
-            raise ValueError(
-                f"Invalid entity path: {path}. "
-                "Entities must be in the holidays namespace."
             )
 
         entity_path = path.split(".")

--- a/holidays/registry.py
+++ b/holidays/registry.py
@@ -308,7 +308,16 @@ class EntityLoader:
     __slots__ = ("entity", "entity_name", "module_name")
 
     def __init__(self, path: str, *args, **kwargs) -> None:
-        """Set up a lazy loader."""
+        """
+        Set up a lazy loader.
+
+        :param path:
+            The path to the entity to be lazy-loaded.
+        :param args:
+            Additional arguments.
+        :param kwargs:
+            Additional keyword arguments.
+        """
         if args:
             raise TypeError(
                 "This is a holidays entity loader class. "

--- a/holidays/registry.py
+++ b/holidays/registry.py
@@ -318,6 +318,9 @@ class EntityLoader:
                 "`from holidays.financial import Entity`."
             )
 
+        if not path.startswith("holidays."):
+            raise ValueError(f"Invalid entity path: {path}")
+
         entity_path = path.split(".")
 
         self.entity = None

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -162,8 +162,3 @@ class TestEntityLoader(TestCase):
             holidays.countries.USA,
         ):
             self.assertIsInstance(create_instance(cls), holidays.countries.UnitedStates)
-
-    def test_invalid_entity_path(self):
-        """Test invalid entity path."""
-        with self.assertRaisesRegex(ValueError, "Invalid entity path"):
-            registry.EntityLoader("invalid.entity.path")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -164,5 +164,6 @@ class TestEntityLoader(TestCase):
             self.assertIsInstance(create_instance(cls), holidays.countries.UnitedStates)
 
     def test_invalid_entity_path(self):
+        """Test invalid entity path."""
         with self.assertRaisesRegex(ValueError, "Invalid entity path"):
             registry.EntityLoader("invalid.entity.path")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -162,3 +162,7 @@ class TestEntityLoader(TestCase):
             holidays.countries.USA,
         ):
             self.assertIsInstance(create_instance(cls), holidays.countries.UnitedStates)
+
+    def test_invalid_path(self):
+        with self.assertRaises(ValueError):
+            registry.EntityLoader("invalid.path")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -162,3 +162,7 @@ class TestEntityLoader(TestCase):
             holidays.countries.USA,
         ):
             self.assertIsInstance(create_instance(cls), holidays.countries.UnitedStates)
+
+    def test_invalid_entity_path(self):
+        with self.assertRaisesRegex(ValueError, "Invalid entity path"):
+            registry.EntityLoader("invalid.entity.path")


### PR DESCRIPTION
Lazy loading mechanism in registry.py utilizes importlib.import_module to resolve holiday entities dynamically based on a provided path. While these paths are currently managed internally, the lack of explicit scope validation poses a risk of importing modules outside the intended holidays namespace if the registry logic is ever extended or modified incorrectly.\n\nTransitioning to a strict prefix check in EntityLoader.__init__ ensures that only modules within the holidays package can be loaded. This improvement follows defensive programming principles, making the registry system more robust against unexpected input and ensuring clear boundaries for dynamic imports without affecting the existing lazy-loading performance.