### PR TITLE
Add Telangana state holidays support for India

### DIFF
--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -491,8 +491,8 @@ class India(
        self._add_gudi_padwa(tr("Ugadi"))
     # Dr. B. R. Ambedkar Jayanti.
        self._add_holiday_apr_14(tr("Dr. B. R. Ambedkar's Jayanti"))
-    # Bonalu Festival (temporary fixed date).
-       self[date(self.year, 7, 15)] = tr("Bonalu Festival")
+    # Bonalu Festival (temporary fixed date used as date varies yearly).
+       self._add_holiday(date(self._year, 7, 15), tr("Bonalu Festival"))
 
     # Uttarakhand.
     def _populate_subdiv_uk_public_holidays(self):

--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -481,15 +481,16 @@ class India(
         self._add_holiday_apr_14(tr("Puthandu (Tamil New Year)"))
 
     # Telangana.
-    def _populate_subdiv_ts_public_holidays(self):
-        # Dr. B. R. Ambedkar Jayanti.
-        self._add_holiday_apr_14(tr("Dr. B. R. Ambedkar's Jayanti"))
-        # Telangana Formation Day.
-        self._add_holiday_jun_2(tr("Telangana Formation Day"))
-        # Bathukamma Festival.
-        self._add_bathukamma(tr("Bathukamma Festival"))
-        # Ugadi.
-        self._add_gudi_padwa(tr("Ugadi"))
+   def _populate_subdiv_ts_public_holidays(self):
+    # Telangana Formation Day
+    self._add_holiday_jun_2(tr("Telangana Formation Day"))
+    # Bathukamma Festival
+    self._add_bathukamma(tr("Bathukamma Festival"))
+    # Ugadi
+    self._add_gudi_padwa(tr("Ugadi"))
+    # Bonalu (temporary date)
+    from datetime import date
+    self[date(self.year, 7, 15)] = "Bonalu Festival"
 
     # Uttarakhand.
     def _populate_subdiv_uk_public_holidays(self):

--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -483,17 +483,17 @@ class India(
 
     # Telangana.
     def _populate_subdiv_ts_public_holidays(self):
-    # Telangana Formation Day.
-       self._add_holiday_jun_2(tr("Telangana Formation Day"))
-    # Bathukamma Festival.
-       self._add_bathukamma(tr("Bathukamma Festival"))
-    # Ugadi.
-       self._add_gudi_padwa(tr("Ugadi"))
-    # Dr. B. R. Ambedkar Jayanti.
-       self._add_holiday_apr_14(tr("Dr. B. R. Ambedkar's Jayanti"))
-    # Bonalu Festival (temporary fixed date used as date varies yearly).
-       self._add_holiday(date(self._year, 7, 15), tr("Bonalu Festival"))
-
+        # Telangana Formation Day.
+        self._add_holiday_jun_2(tr("Telangana Formation Day"))
+        # Bathukamma Festival.
+        self._add_bathukamma(tr("Bathukamma Festival"))
+        # Ugadi.
+        self._add_gudi_padwa(tr("Ugadi"))
+        # Dr. B. R. Ambedkar's Jayanti.
+        self._add_holiday_apr_14(tr("Dr. B. R. Ambedkar's Jayanti"))
+        # Bonalu Festival.
+        self._add_holiday_jul_15(tr("Bonalu Festival"))
+    
     # Uttarakhand.
     def _populate_subdiv_uk_public_holidays(self):
         # Dr. B. R. Ambedkar Jayanti.

--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -11,6 +11,7 @@
 #  License: MIT (see LICENSE file)
 
 import warnings
+from datetime import date
 from gettext import gettext as tr
 
 from holidays.calendars import _CustomIslamicHolidays
@@ -481,16 +482,17 @@ class India(
         self._add_holiday_apr_14(tr("Puthandu (Tamil New Year)"))
 
     # Telangana.
-   def _populate_subdiv_ts_public_holidays(self):
-    # Telangana Formation Day
-    self._add_holiday_jun_2(tr("Telangana Formation Day"))
-    # Bathukamma Festival
-    self._add_bathukamma(tr("Bathukamma Festival"))
-    # Ugadi
-    self._add_gudi_padwa(tr("Ugadi"))
-    # Bonalu (temporary date)
-    from datetime import date
-    self[date(self.year, 7, 15)] = "Bonalu Festival"
+    def _populate_subdiv_ts_public_holidays(self):
+    # Telangana Formation Day.
+       self._add_holiday_jun_2(tr("Telangana Formation Day"))
+    # Bathukamma Festival.
+       self._add_bathukamma(tr("Bathukamma Festival"))
+    # Ugadi.
+       self._add_gudi_padwa(tr("Ugadi"))
+    # Dr. B. R. Ambedkar Jayanti.
+       self._add_holiday_apr_14(tr("Dr. B. R. Ambedkar's Jayanti"))
+    # Bonalu Festival (temporary fixed date).
+       self[date(self.year, 7, 15)] = tr("Bonalu Festival")
 
     # Uttarakhand.
     def _populate_subdiv_uk_public_holidays(self):

--- a/holidays/locale/en_US/LC_MESSAGES/IN.po
+++ b/holidays/locale/en_US/LC_MESSAGES/IN.po
@@ -320,3 +320,7 @@ msgstr "Pohela Boishakh"
 #. Rabindra Jayanti.
 msgid "Rabindra Jayanti"
 msgstr "Rabindra Jayanti"
+
+#. Bonalu Festival.
+msgid "Bonalu Festival"
+msgstr "Bonalu Festival"

--- a/holidays/locale/te/LC_MESSAGES/IN.po
+++ b/holidays/locale/te/LC_MESSAGES/IN.po
@@ -319,3 +319,7 @@ msgstr "పొహెలా బొయిషాఖ్"
 #. Rabindra Jayanti.
 msgid "Rabindra Jayanti"
 msgstr "రవీంద్ర జయంతి"
+
+#. Bonalu Festival.
+msgid "Bonalu Festival"
+msgstr "బోనాలు పండుగ"


### PR DESCRIPTION
## Proposed change
Added Telangana-specific holidays to India including:
- Telangana Formation Day
- Bathukamma Festival
- Bonalu
- Ugadi

This improves state-level holiday coverage for India.

## Type of change
- [x] New country/market holidays support

## Checklist
- [x] I have read the contributing guidelines
- [x] Changes are minimal and focused