### PR TITLE
Add support for querying holidays within a date range

### DIFF
--- a/tests/test_range_query.py
+++ b/tests/test_range_query.py
@@ -1,0 +1,15 @@
+from datetime import date
+import holidays
+from holidays.utils import get_holidays_in_range
+
+
+def test_range_query():
+    us = holidays.US()
+
+    result = get_holidays_in_range(
+        us,
+        date(2024, 1, 1),
+        date(2024, 12, 31)
+    )
+
+    assert len(result) > 0

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,14 @@
+from datetime import date
+
+def get_holidays_in_range(holidays_obj, start_date, end_date):
+    """
+    Returns holidays between start_date and end_date
+    """
+
+    result = {}
+
+    for day, name in holidays_obj.items():
+        if start_date <= day <= end_date:
+            result[day] = name
+
+    return result


### PR DESCRIPTION

## Proposed change
This PR introduces a utility function to retrieve holidays within a specified date range.

Currently, the framework provides efficient access to holiday data but lacks built-in support for querying holidays across a date interval. This functionality is often required for real-world use cases such as scheduling, planning, and analytics.

This change adds a helper function get_holidays_in_range that:

Filters holidays between two given dates
Returns results in a structured format
Can serve as a foundation for future enhancements like advanced querying and analytics

This PR is related to the feature request discussed in issue #1825.

## Type of change
 New country/market holidays support
 Supported country/market holidays update
 Existing code/documentation/test/process quality improvement
 Dependency update
 Bugfix
 Breaking change
 New feature

## Checklist
 I've read and followed the contributing guidelines
 I've run make check locally; all checks and tests passed