### PR TITLE
Add support for filtering only observed holidays

### DIFF
--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -235,6 +235,7 @@ class HolidayBase(dict[date, str]):
         years: YearArg | None = None,
         expand: bool = True,
         observed: bool = True,
+        only_observed: bool = False,
         subdiv: str | None = None,
         prov: str | None = None,  # Deprecated.
         state: str | None = None,  # Deprecated.
@@ -372,6 +373,7 @@ class HolidayBase(dict[date, str]):
         self.has_substituted_holidays = has_substituted_holidays
         self.language = language
         self.observed = observed
+        self.only_observed = only_observed
         self.subdiv = subdiv
         self.weekend_workdays = getattr(self, "weekend_workdays", set())
         self.years = _normalize_arguments(int, years)
@@ -800,7 +802,10 @@ class HolidayBase(dict[date, str]):
 
         if dt.year != self._year:
             return None
-
+        if getattr(self,"only_observed",False):
+            label = getattr(self,"observed_label",None)
+            if label and label not in name:
+                return None
         self[dt] = self.tr(name)
         return dt
 

--- a/holidays/tempCodeRunnerFile.py
+++ b/holidays/tempCodeRunnerFile.py
@@ -1,0 +1,24 @@
+"""Returns True if the year is leap. Returns False otherwise."""
+        return isleap(self._year)
+
+    def _add_holiday(self, name: str, *args) -> date | None:
+        """Add a holiday."""
+        if not args:
+            raise TypeError("Incorrect number of arguments.")
+
+        dt = args if len(args) > 1 else args[0]
+        dt = dt if isinstance(dt, date) else date(self._year, *dt)
+
+        if dt.year != self._year:
+            return None
+        if getattr(self,"only_observed",False) and getattr(self,"observed_label","")not in name:
+            return None
+        self[dt] = self.tr(name)
+        return dt
+
+    def _add_multiday_holiday(
+        self, start_date: date, duration_days: int, *, name: str | None = None
+    ) -> set[date]:
+        """Add a multi-day holiday.
+
+        Args:


### PR DESCRIPTION
## Proposed change

Currently, when `observed=True`, the API returns both statutory and observed holidays. This can feel like duplication for certain use cases where only observed dates are needed.

There is no built-in way to retrieve only observed holidays, requiring users to manually filter holiday names, which is not reliable.

This PR introduces an optional `only_observed` check in `_add_holiday()` to allow filtering only observed holidays.

- Uses `getattr` to safely handle cases where `observed_label` may not be defined
- Does not change existing behavior unless explicitly used
- Avoids manual string filtering at the user level

Would appreciate feedback on whether this aligns with the intended design.

---

## Type of change

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [x] New feature (new `holidays` functionality in general)

---

## Checklist

- [x] I've read and followed the contributing guidelines.
- [ ] I've run `make check` locally; all checks and tests passed.