### PR TITLE
pytest9 fix: use [tool.pytest.ini_options] instead of [tool.pytest] with dotted keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,14 +119,14 @@ overrides = [
   { module = "holidays.groups.*", disable_error_code = [ "attr-defined" ] },
 ]
 
-[tool.pytest]
-ini_options.addopts = [
+[tool.pytest.ini_options]
+addopts = [
   "--cov-fail-under=100",
 ]
-ini_options.filterwarnings = [
+filterwarnings = [
   "ignore::DeprecationWarning:holidays.deprecations.v1_incompatibility",
 ]
-ini_options.testpaths = [ "tests" ]
+testpaths = [ "tests" ]
 
 [tool.coverage]
 run.branch = true


### PR DESCRIPTION

Pytest 9 rejects using [tool.pytest] with ini_options.* dotted keys. Use the standard [tool.pytest.ini_options] section instead.

Made-with: Cursor

<!--
  Thanks for contributing to holidays!
-->

## Proposed change

I am working on updating pytest to 9.x.x in Fedora and holidays fail. This PR addresses changes in pytest to make it compatible with 9, it also works with pytest 8.

Your PR description goes here.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [x] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [ ] I've run `make check` locally; all checks and tests passed.
pyproject-fmf check failed and reverted my changes

<!--
  Thanks again for your contribution!
-->
