### PR TITLE
Clarify handling of duplicate translations in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,16 @@ the list of supported translations for the country in the README.md.
     `msgstr` lines there as missing work or duplicate the `msgid` text into `msgstr` unless
     maintainers explicitly ask for a change.
 
+!!! note "Duplicate translations across per-entity files"
+
+    When the same holiday name (e.g., "New Year's Day") appears across 
+    multiple countries in the same language, each country currently 
+    generates a separate translation entry. This results in duplicate 
+    msgids across per-entity .po files, which adds redundancy to the 
+    localization workflow. See issue #1658 for the ongoing discussion on
+    moving towards a per-locale approach that would consolidate 
+    translations into one file per language.
+
 If the translation already exists you'll just need to update it with the new template entries
 (your .po file editor may help you to do that with no hassle).
 


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

The Localization section explained how per-entity .po files are generated but did not mention the redundancy that occurs when the same holiday name appears across multiple countries in the same language. Added a note to make this limitation visible to new contributors, as it provides useful context for understanding the current workflow.

Related to issue #1658, which proposes restructuring to a per-locale approach to address this redundancy.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
