### PR TITLE
PK: fix comment inconsistency for Eid ul-Fitr and Eid ul-Adha

### DIFF
--- a/holidays/countries/pakistan.py
+++ b/holidays/countries/pakistan.py
@@ -76,13 +76,13 @@ class Pakistan(HolidayBase, InternationalHolidays, IslamicHolidays):
         # Quaid-e-Azam Day.
         self._add_holiday_dec_25(tr("Quaid-e-Azam Day"))
 
-        # Eid al-Fitr.
+        # Eid-ul-Fitr.
         name = tr("Eid-ul-Fitr")
         self._add_eid_al_fitr_day(name)
         self._add_eid_al_fitr_day_two(name)
         self._add_eid_al_fitr_day_three(name)
 
-        # Eid al-Adha.
+        # Eid-ul-Adha.
         name = tr("Eid-ul-Adha")
         self._add_eid_al_adha_day(name)
         self._add_eid_al_adha_day_two(name)


### PR DESCRIPTION
Comments on lines 79 and 85 in holidays/countries/pk.py used "al"  (Eid al-Fitr, Eid al-Adha) while the actual holiday name strings  directly below use "ul" (Eid-ul-Fitr, Eid-ul-Adha).

Updated the comments to be consistent with the string values,  which reflect Pakistan's official and commonly used spelling.

No logic or functionality is changed.

<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Your PR description goes here.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [ ] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
