### PR TITLE
Add reference-based validation test for Diwali and Holi in India Holidays

### DIFF
--- a/tests/countries/test_india.py
+++ b/tests/countries/test_india.py
@@ -1118,3 +1118,31 @@ class TestIndia(CommonCountryTests, TestCase):
         self.assertEqual(
             India(subdiv="OR", years=2023).keys(), India(subdiv="OD", years=2023).keys()
         )
+
+    def test_diwali_reference_validation(self):
+        # References:
+        # https://en.wikipedia.org/wiki/Diwali
+        # https://www.timeanddate.com/holidays/india/diwali
+        expected_dates = {
+            2020: "2020-11-14",
+            2021: "2021-11-04",
+            2022: "2022-10-24",
+            2023: "2023-11-12",
+            2024: "2024-10-31",
+        }
+        for year, expected_date in expected_dates.items():
+            holidays = India(years=year)
+            self.assertIn(expected_date, holidays)
+
+    def test_holi_reference_validation(self):
+        # References:
+        # https://en.wikipedia.org/wiki/Holi
+        # https://www.timeanddate.com/holidays/india/holi
+        expected_dates = {
+            2022: "2022-03-18",
+            2023: "2023-03-08",
+            2024: "2024-03-25",
+        }
+        for year, expected_date in expected_dates.items():
+            holidays = India(categories=OPTIONAL, years=year)
+            self.assertIn(expected_date, holidays)


### PR DESCRIPTION

## Proposed change

This PR adds a reference-based validation test for Diwali and Holi in India holidays.

The test verifies known historical dates across multiple years and includes external references to improve traceability and confidence in holiday calculations.

While working on this, I also observed that holiday dates (e.g., Diwali 2024) may vary depending on calculation approaches, which highlights the importance of consistent handling of lunar-based holidays.

No changes to existing logic or tests.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [ x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [ x] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
