### PR TITLE
Add concrete example for retrieving country-specific holidays

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -248,6 +248,14 @@ False
 ```
 
 To find the nth working day after the specified date:
+The `get_nth_working_day` function can also be used to get the next or previous working day:
+
+```python
+# Next working day
+>>> us_holidays.get_nth_working_day("2024-12-20", 1)
+
+# Previous working day
+>>> us_holidays.get_nth_working_day("2024-12-20", -1)
 
 ``` python
 >>> us_holidays.get_nth_working_day("2024-12-20", 5)

--- a/docs/holiday_categories.md
+++ b/docs/holiday_categories.md
@@ -88,7 +88,7 @@ Examples:
 - Cultural observances with optional recognition
 - Religious holidays for minority populations
 
-#### MANDATORY *(deprecated)*
+#### MANDATORY _(deprecated)_
 
 Holidays that were legally required to be observed in specific contexts. Previously used in Macau, where "Mandatory (Statutory) Holidays" have since been reclassified under the `PUBLIC` category, and "General Holidays" are now included in the `OPTIONAL` category, following the same approach as in Hong Kong.
 
@@ -382,3 +382,31 @@ When contributing new countries or updating existing ones:
 3. Classify each holiday according to its official status and cultural significance
 4. Document the reasoning for category assignments
 5. Provide examples in tests demonstrating category usage
+
+## Example: Retrieving Holidays for a Country
+
+This example demonstrates how to retrieve holidays for a specific country, check if a date is a holiday, and understand what data is returned.
+
+```python
+import holidays
+
+# Get holidays for India
+india = holidays.country_holidays('IN')
+
+# Check if a specific date is a holiday
+print('2024-01-26' in india)  # True (Republic Day)
+
+# Get the holiday name
+print(india.get('2024-01-26'))  # Republic Day
+
+### What does this return?
+
+The `country_holidays('IN')` function returns a dictionary-like object where:
+
+- Keys are dates (YYYY-MM-DD format)
+- Values are holiday names
+This allows you to:
+- Check if a date is a holiday using `in`
+- Retrieve holiday names using `.get()`
+- Iterate through all holidays
+```


### PR DESCRIPTION
## Proposed change

This PR adds a concrete example demonstrating how to retrieve country-specific holidays using the `holidays` library.

The example shows:
- How to fetch holidays for a country (India)
- How to check if a date is a holiday
- How to retrieve the holiday name

Fixes #3514