### PR TITLE
Make vacanza CLI arguments optional and improve usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2026,3 +2026,32 @@ requests](https://github.com/vacanza/holidays/pulls) are always welcome. Please 
 
 Code and documentation are available according to the MIT License (see
 [LICENSE](https://github.com/vacanza/holidays/blob/dev/LICENSE)).
+
+
+This script generates holiday calendar (.ics) files for different countries using the holidays library.
+## Usage
+
+Run the script using:
+
+python vacanza.py [country] [year or range] [type]
+Examples
+# Default usage (no arguments)
+python vacanza.py
+
+# Specific country and year
+python vacanza.py IN 2024
+
+# Multiple years
+python vacanza.py US 2020-2024
+
+# Only public holidays
+python vacanza.py IN 2024 public
+Default Behavior
+
+If no arguments are provided, the script uses:
+
+Country: IN (India)
+Year: 2024
+Output
+
+The script generates .ics files that can be imported into calendar applications like Google Calendar or Outlook.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -583,3 +583,8 @@ Generate `.ics` files with categories, language, and subdivisions.
 
 For advanced features and customization of the exported `.ics` output, consider using
 the [icalendar](https://github.com/collective/icalendar) package.
+
+
+
+
+

--- a/docs/vacanza.py
+++ b/docs/vacanza.py
@@ -1,0 +1,61 @@
+import sys
+from holidays import country_holidays
+from holidays.ical import ICalExporter
+
+
+def parse_years(year_arg):
+    if "-" in year_arg:
+        start, end = map(int, year_arg.split("-"))
+        return range(start, end + 1)
+    else:
+        return [int(year_arg)]
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python vacanza.py <COUNTRY_CODE> [YEAR or YEAR_RANGE] [CATEGORY]")
+        print("Example: python vacanza.py IN 2025")
+        sys.exit(1)
+
+    country_code = sys.argv[1]
+
+    # Default values
+    years = range(2020, 2031)
+    category = None
+
+    # Parse year
+    if len(sys.argv) >= 3:
+        years = parse_years(sys.argv[2])
+
+    # Parse category
+    if len(sys.argv) >= 4:
+        category = sys.argv[3]
+
+    try:
+        holidays_obj = country_holidays(country_code)
+
+        supported_categories = getattr(holidays_obj, "supported_categories", ["public"])
+
+        if category:
+            categories_to_use = [category]
+        else:
+            categories_to_use = supported_categories
+
+        for cat in categories_to_use:
+            holidays = country_holidays(
+                country_code,
+                years=years,
+                categories=cat
+            )
+
+            filename = f"{country_code}_{cat}.ics"
+            ICalExporter(holidays).save_ics(filename)
+
+            print(f"Generated: {filename}")
+
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/holidays/examples/vacanza.py
+++ b/holidays/examples/vacanza.py
@@ -1,0 +1,96 @@
+import argparse
+import holidays
+from holidays.ical import ICalExporter
+
+
+def parse_years(year_input):
+    try:
+        if "-" in year_input:
+            start, end = map(int, year_input.split("-"))
+            if start > end:
+                raise ValueError
+            return list(range(start, end + 1))
+        return [int(year_input)]
+    except Exception:
+        raise ValueError("Invalid year format. Use 2025 or 2020-2025")
+
+
+def get_country(country_code):
+    try:
+        return getattr(holidays, country_code.upper())
+    except AttributeError:
+        raise ValueError(f"Unsupported country code: {country_code}")
+
+
+def generate_ics(country_code, years, public_only=False):
+    country_class = get_country(country_code)
+
+    print(f"\nGenerating holidays for {country_code.upper()}...")
+
+    categories = getattr(country_class, "supported_categories", ["public"])
+
+    if public_only:
+        categories = ["public"]
+
+    for category in categories:
+        try:
+            holiday_obj = country_class(
+                years=years,
+                categories=category,
+                
+            )
+
+            filename = f"{country_code.upper()}{category.upper()}{years[0]}"
+            if len(years) > 1:
+                filename += f"-{years[-1]}"
+            filename += ".ics"
+
+            ICalExporter(holiday_obj).save_ics(filename)
+
+            print(f"Saved: {filename}")
+
+        except Exception as e:
+            print(f"Skipping {category}: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate .ics holiday files"
+    )
+
+    # ✅ MADE OPTIONAL WITH DEFAULTS
+    parser.add_argument(
+        "country",
+        nargs="?",
+        default="IN",
+        help="Country code (default: IN)",
+    )
+
+    parser.add_argument(
+        "years",
+        nargs="?",
+        default="2024",
+        help="Year or range (default: 2024)",
+    )
+
+    parser.add_argument(
+        "type",
+        nargs="?",
+        default=None,
+        help="Use 'public' for only public holidays",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        years = parse_years(args.years)
+        public_only = args.type == "public"
+
+        generate_ics(args.country, years, public_only)
+
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Summary

This PR improves the usability of the `vacanza.py` script by making command-line arguments optional.

### Changes

* Made `country` and `years` arguments optional with default values
* Removed unsupported `include_sundays` argument for compatibility
* Improved overall CLI usability
* Updated README with usage instructions and examples

### Usage

The script can now be run without arguments:

```
python vacanza.py
```

Examples:

```
python vacanza.py IN 2024
python vacanza.py US 2020-2024 public
```

### Motivation

Previously, the script required mandatory arguments, which caused errors when not provided.
This change enhances user experience and makes the tool more beginner-friendly.
