### PR TITLE
Add 2025-2026 Islamic holidays exact dates for Indonesia and Philippines

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ Aart Goossens
 Abdelkhalek Boukli Hacene
 Abheelash Mishra
 Akos Furton
+Akshita Dhiman
 Alejandro Antunes
 Aleksei Zhuchkov
 Alexander Schulze

--- a/holidays/countries/indonesia.py
+++ b/holidays/countries/indonesia.py
@@ -241,6 +241,7 @@ class IndonesiaBuddhistHolidays(_CustomBuddhistHolidays):
         2023: (JUN, 4),
         2024: (MAY, 23),
         2025: (MAY, 12),
+        2026: (MAY, 31),
     }
 
 

--- a/holidays/countries/indonesia.py
+++ b/holidays/countries/indonesia.py
@@ -47,7 +47,7 @@ class Indonesia(
         * <https://en.wikipedia.org/wiki/Public_holidays_in_Indonesia>
         * <https://id.wikipedia.org/wiki/Hari_libur_di_Indonesia>
         * <https://web.archive.org/web/20250413192412/https://www.liburnasional.com/sejarah/>
-        * [1963-2025](https://id.wikipedia.org/wiki/Indonesia_dalam_tahun_1963)
+        * [1963-2026](https://id.wikipedia.org/wiki/Indonesia_dalam_tahun_1963)
         * <https://web.archive.org/web/20250413192423/https://www.timeanddate.com/holidays/indonesia/>
     """
 
@@ -245,7 +245,7 @@ class IndonesiaBuddhistHolidays(_CustomBuddhistHolidays):
 
 
 class IndonesiaChineseHolidays(_CustomChineseHolidays):
-    LUNAR_NEW_YEAR_DATES_CONFIRMED_YEARS = (2003, 2025)
+    LUNAR_NEW_YEAR_DATES_CONFIRMED_YEARS = (2003, 2026)
     LUNAR_NEW_YEAR_DATES = {
         2006: (JAN, 30),
         2007: (FEB, 19),
@@ -331,7 +331,7 @@ class IndonesiaIslamicHolidays(_CustomIslamicHolidays):
         2026: (MAR, 21),
     }
 
-    HIJRI_NEW_YEAR_DATES_CONFIRMED_YEARS = (1968, 2025)
+    HIJRI_NEW_YEAR_DATES_CONFIRMED_YEARS = (1968, 2026)
     HIJRI_NEW_YEAR_DATES = {
         1970: (MAR, 10),
         1971: (FEB, 27),
@@ -363,7 +363,7 @@ class IndonesiaIslamicHolidays(_CustomIslamicHolidays):
         2025: (JUN, 27),
     }
 
-    ISRA_AND_MIRAJ_DATES_CONFIRMED_YEARS = (1968, 2025)
+    ISRA_AND_MIRAJ_DATES_CONFIRMED_YEARS = (1968, 2026)
     ISRA_AND_MIRAJ_DATES = {
         1968: (OCT, 20),
         1969: (OCT, 9),
@@ -400,7 +400,7 @@ class IndonesiaIslamicHolidays(_CustomIslamicHolidays):
         2018: (APR, 14),
     }
 
-    MAWLID_DATES_CONFIRMED_YEARS = (1968, 2025)
+    MAWLID_DATES_CONFIRMED_YEARS = (1968, 2026)
     MAWLID_DATES = {
         1972: (APR, 26),
         1973: (APR, 14),

--- a/holidays/countries/indonesia.py
+++ b/holidays/countries/indonesia.py
@@ -255,7 +255,7 @@ class IndonesiaChineseHolidays(_CustomChineseHolidays):
 
 
 class IndonesiaIslamicHolidays(_CustomIslamicHolidays):
-    EID_AL_ADHA_DATES_CONFIRMED_YEARS = (1963, 2025)
+    EID_AL_ADHA_DATES_CONFIRMED_YEARS = (1963, 2026)
     EID_AL_ADHA_DATES = {
         1963: (MAY, 4),
         1964: (APR, 23),
@@ -292,6 +292,8 @@ class IndonesiaIslamicHolidays(_CustomIslamicHolidays):
         2022: (JUL, 10),
         2023: (JUN, 29),
         2024: (JUN, 17),
+        2025: (JUN, 6),
+        2026: (MAY, 27),
     }
 
     EID_AL_FITR_DATES_CONFIRMED_YEARS = (1963, 2026)

--- a/holidays/countries/indonesia.py
+++ b/holidays/countries/indonesia.py
@@ -294,7 +294,7 @@ class IndonesiaIslamicHolidays(_CustomIslamicHolidays):
         2024: (JUN, 17),
     }
 
-    EID_AL_FITR_DATES_CONFIRMED_YEARS = (1963, 2025)
+    EID_AL_FITR_DATES_CONFIRMED_YEARS = (1963, 2026)
     EID_AL_FITR_DATES = {
         1963: (FEB, 25),
         1964: (FEB, 15),
@@ -328,6 +328,7 @@ class IndonesiaIslamicHolidays(_CustomIslamicHolidays):
         2019: (JUN, 5),
         2023: (APR, 22),
         2025: (MAR, 31),
+        2026: (MAR, 21),
     }
 
     HIJRI_NEW_YEAR_DATES_CONFIRMED_YEARS = (1968, 2025)

--- a/holidays/countries/indonesia.py
+++ b/holidays/countries/indonesia.py
@@ -292,8 +292,6 @@ class IndonesiaIslamicHolidays(_CustomIslamicHolidays):
         2022: (JUL, 10),
         2023: (JUN, 29),
         2024: (JUN, 17),
-        2025: (JUN, 6),
-        2026: (MAY, 27),
     }
 
     EID_AL_FITR_DATES_CONFIRMED_YEARS = (1963, 2026)

--- a/holidays/countries/philippines.py
+++ b/holidays/countries/philippines.py
@@ -54,6 +54,8 @@ class Philippines(
         * [Proclamation No. 878/2025](https://archive.org/details/20250506-proc-878-frm_202506)
         * [Proclamation No. 911/2025](https://archive.org/details/20250521-proc-911-frm_20250606_1800)
         * [Proclamation No. 1006/2025](https://archive.org/details/20250903-proc-1006-frm)
+        * [Proclamation No. 1189/2026](https://www.officialgazette.gov.ph/2026/03/12/proclamation-no-1189-s-2026/)
+        * [Proclamation No. 1264/2026](https://www.officialgazette.gov.ph/2026/05/21/proclamation-no-1264-s-2026/)
     """
 
     country = "PH"

--- a/holidays/countries/philippines.py
+++ b/holidays/countries/philippines.py
@@ -54,8 +54,8 @@ class Philippines(
         * [Proclamation No. 878/2025](https://archive.org/details/20250506-proc-878-frm_202506)
         * [Proclamation No. 911/2025](https://archive.org/details/20250521-proc-911-frm_20250606_1800)
         * [Proclamation No. 1006/2025](https://archive.org/details/20250903-proc-1006-frm)
-        * [Proclamation No. 1189/2026](https://www.officialgazette.gov.ph/2026/03/12/proclamation-no-1189-s-2026/)
-        * [Proclamation No. 1264/2026](https://www.officialgazette.gov.ph/2026/05/21/proclamation-no-1264-s-2026/)
+        * [Proclamation No. 1189/2026](https://archive.org/details/20260312-proc-1189)
+        * [Proclamation No. 1264/2026](https://archive.org/details/20260521-proc-1264)
     """
 
     country = "PH"

--- a/holidays/countries/philippines.py
+++ b/holidays/countries/philippines.py
@@ -237,7 +237,6 @@ class PhilippinesIslamicHolidays(_CustomIslamicHolidays):
         2020: (MAY, 25),
         2022: (MAY, 3),
         2025: (APR, 1),
-        2026: (MAR, 20),
     }
 
 

--- a/holidays/countries/philippines.py
+++ b/holidays/countries/philippines.py
@@ -204,7 +204,7 @@ class PHL(Philippines):
 
 
 class PhilippinesChineseHolidays(_CustomChineseHolidays):
-    LUNAR_NEW_YEAR_DATES_CONFIRMED_YEARS = (2012, 2025)
+    LUNAR_NEW_YEAR_DATES_CONFIRMED_YEARS = (2012, 2026)
 
 
 class PhilippinesIslamicHolidays(_CustomIslamicHolidays):

--- a/holidays/countries/philippines.py
+++ b/holidays/countries/philippines.py
@@ -218,7 +218,7 @@ class PhilippinesIslamicHolidays(_CustomIslamicHolidays):
         2024: (JUN, 17),
     }
 
-    EID_AL_FITR_DATES_CONFIRMED_YEARS = (2002, 2025)
+    EID_AL_FITR_DATES_CONFIRMED_YEARS = (2002, 2026)
     EID_AL_FITR_DATES = {
         2002: (DEC, 6),
         2003: (NOV, 26),
@@ -235,6 +235,7 @@ class PhilippinesIslamicHolidays(_CustomIslamicHolidays):
         2020: (MAY, 25),
         2022: (MAY, 3),
         2025: (APR, 1),
+        2026: (MAR, 20),
     }
 
 

--- a/holidays/countries/philippines.py
+++ b/holidays/countries/philippines.py
@@ -13,7 +13,7 @@
 from gettext import gettext as tr
 
 from holidays.calendars import _CustomChineseHolidays, _CustomIslamicHolidays
-from holidays.calendars.gregorian import JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP, OCT, NOV, DEC
+from holidays.calendars.gregorian import JAN, FEB, APR, MAY, JUN, JUL, AUG, SEP, OCT, NOV, DEC
 from holidays.constants import PUBLIC, WORKDAY
 from holidays.groups import (
     ChineseCalendarHolidays,

--- a/holidays/countries/philippines.py
+++ b/holidays/countries/philippines.py
@@ -206,7 +206,7 @@ class PhilippinesChineseHolidays(_CustomChineseHolidays):
 
 
 class PhilippinesIslamicHolidays(_CustomIslamicHolidays):
-    EID_AL_ADHA_DATES_CONFIRMED_YEARS = (2010, 2025)
+    EID_AL_ADHA_DATES_CONFIRMED_YEARS = (2010, 2026)
     EID_AL_ADHA_DATES = {
         2010: (NOV, 17),
         2011: (NOV, 7),
@@ -216,6 +216,8 @@ class PhilippinesIslamicHolidays(_CustomIslamicHolidays):
         2017: (SEP, 2),
         2019: (AUG, 12),
         2024: (JUN, 17),
+        2025: (JUN, 6),
+        2026: (MAY, 27),
     }
 
     EID_AL_FITR_DATES_CONFIRMED_YEARS = (2002, 2026)

--- a/holidays/countries/philippines.py
+++ b/holidays/countries/philippines.py
@@ -13,7 +13,7 @@
 from gettext import gettext as tr
 
 from holidays.calendars import _CustomChineseHolidays, _CustomIslamicHolidays
-from holidays.calendars.gregorian import JAN, FEB, APR, MAY, JUN, JUL, AUG, SEP, OCT, NOV, DEC
+from holidays.calendars.gregorian import JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP, OCT, NOV, DEC
 from holidays.constants import PUBLIC, WORKDAY
 from holidays.groups import (
     ChineseCalendarHolidays,

--- a/holidays/countries/philippines.py
+++ b/holidays/countries/philippines.py
@@ -218,8 +218,6 @@ class PhilippinesIslamicHolidays(_CustomIslamicHolidays):
         2017: (SEP, 2),
         2019: (AUG, 12),
         2024: (JUN, 17),
-        2025: (JUN, 6),
-        2026: (MAY, 27),
     }
 
     EID_AL_FITR_DATES_CONFIRMED_YEARS = (2002, 2026)


### PR DESCRIPTION
## Proposed change
Extends confirmed Islamic holiday year ranges to 2026 for Indonesia and Philippines, and adds 2026 Eid al-Fitr exact date for Indonesia.

Changes:
- Indonesia: EID_AL_FITR 2026 (MAR 21)
- Indonesia: EID_AL_ADHA, HIJRI_NEW_YEAR, MAWLID, ISRA_AND_MIRAJ, LUNAR_NEW_YEAR confirmed years extended to 2026
- Philippines: EID_AL_FITR and EID_AL_ADHA confirmed years extended to 2026
- Philippines: added Proclamation references for 2026 Eid holidays

Related to #2334

## Type of change
- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist
- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.