### PR TITLE
Migrate Mozambique tests to new test case standards

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -191,8 +191,8 @@ Tharupahan Jayawardana
 Thomas Bøvith
 Tommy Sparber
 Tudor Văran
-Vanshika Pundir
 Vaishnavi Bardapure
+Vanshika Pundir
 Victor Luna
 Victor Miti
 Vikash Kumar

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -192,6 +192,7 @@ Thomas Bøvith
 Tommy Sparber
 Tudor Văran
 Vanshika Pundir
+Vaishnavi Bardapure
 Victor Luna
 Victor Miti
 Vikash Kumar

--- a/tests/countries/test_mozambique.py
+++ b/tests/countries/test_mozambique.py
@@ -93,6 +93,7 @@ class TestMozambique(CommonCountryTests, TestCase):
         )
         obs_dts = (
             "2014-09-08",
+            "2025-09-08",
         )
         self.assertHolidayName(f"{name} (ponte)", obs_dts)
         self.assertNoNonObservedHoliday(obs_dts)

--- a/tests/countries/test_mozambique.py
+++ b/tests/countries/test_mozambique.py
@@ -21,7 +21,7 @@ class TestMozambique(CommonCountryTests, TestCase):
     def setUpClass(cls):
         super().setUpClass(Mozambique)
 
-    def test_new_years_day(self):
+    def test_international_fraternalism_day(self):
         name = "Dia da Fraternidade universal"
         self.assertHolidayName(name, (f"{year}-01-01" for year in self.full_range))
         obs_dts = (
@@ -53,7 +53,7 @@ class TestMozambique(CommonCountryTests, TestCase):
         self.assertHolidayName(f"{name} (ponte)", obs_dts)
         self.assertNoNonObservedHoliday(obs_dts)
 
-    def test_workers_day(self):
+    def test_international_workers_day(self):
         name = "Dia Internacional dos Trabalhadores"
         self.assertHolidayName(name, (f"{year}-05-01" for year in self.full_range))
         obs_dts = (

--- a/tests/countries/test_mozambique.py
+++ b/tests/countries/test_mozambique.py
@@ -22,46 +22,97 @@ class TestMozambique(CommonCountryTests, TestCase):
         super().setUpClass(Mozambique)
 
     def test_new_years_day(self):
+        name = "Dia da Fraternidade universal"
         self.assertHolidayName(
-            "Dia da Fraternidade universal",
+            name,
             (f"{year}-01-01" for year in self.full_range),
         )
+        obs_dts = (
+            "2012-01-02",
+            "2017-01-02",
+            "2023-01-02",
+        )
+        self.assertHolidayName(f"{name} (ponte)", obs_dts)
+        self.assertNoNonObservedHoliday(obs_dts)
 
     def test_heroes_day(self):
+        name = "Dia dos Heróis Moçambicanos"
         self.assertHolidayName(
-            "Dia dos Heróis Moçambicanos",
+            name,
             (f"{year}-02-03" for year in self.full_range),
         )
+        obs_dts = (
+            "2013-02-04",
+            "2019-02-04",
+        )
+        self.assertHolidayName(f"{name} (ponte)", obs_dts)
+        self.assertNoNonObservedHoliday(obs_dts)
 
     def test_womens_day(self):
+        name = "Dia da Mulher Moçambicana"
         self.assertHolidayName(
-            "Dia da Mulher Moçambicana",
+            name,
             (f"{year}-04-07" for year in self.full_range),
         )
+        obs_dts = (
+            "2013-04-08",
+            "2019-04-08",
+        )
+        self.assertHolidayName(f"{name} (ponte)", obs_dts)
+        self.assertNoNonObservedHoliday(obs_dts)
 
     def test_workers_day(self):
+        name = "Dia Internacional dos Trabalhadores"
         self.assertHolidayName(
-            "Dia Internacional dos Trabalhadores",
+            name,
             (f"{year}-05-01" for year in self.full_range),
         )
+        obs_dts = (
+            "2011-05-02",
+            "2016-05-02",
+            "2022-05-02",
+        )
+        self.assertHolidayName(f"{name} (ponte)", obs_dts)
+        self.assertNoNonObservedHoliday(obs_dts)
 
     def test_independence_day(self):
+        name = "Dia da Independência Nacional"
         self.assertHolidayName(
-            "Dia da Independência Nacional",
+            name,
             (f"{year}-06-25" for year in self.full_range),
         )
+        obs_dts = (
+            "2017-06-26",
+            "2023-06-26",
+        )
+        self.assertHolidayName(f"{name} (ponte)", obs_dts)
+        self.assertNoNonObservedHoliday(obs_dts)
 
     def test_victory_day(self):
+        name = "Dia da Vitória"
         self.assertHolidayName(
-            "Dia da Vitória",
+            name,
             (f"{year}-09-07" for year in self.full_range),
         )
+        obs_dts = (
+            "2014-09-08",
+        )
+        self.assertHolidayName(f"{name} (ponte)", obs_dts)
+        self.assertNoNonObservedHoliday(obs_dts)
 
     def test_armed_forces_day(self):
+        name = "Dia das Forças Armadas de Libertação Nacional"
         self.assertHolidayName(
-            "Dia das Forças Armadas de Libertação Nacional",
+            name,
             (f"{year}-09-25" for year in self.full_range),
         )
+        obs_dts = (
+            "2011-09-26",
+            "2016-09-26",
+            "2022-09-26",
+        )
+        self.assertHolidayName(f"{name} (ponte)", obs_dts)
+        self.assertNoNonObservedHoliday(obs_dts)
 
     def test_peace_and_reconciliation_day(self):
         name = "Dia da Paz e Reconciliação"
@@ -70,39 +121,26 @@ class TestMozambique(CommonCountryTests, TestCase):
             (f"{year}-10-04" for year in range(1993, self.end_year)),
         )
         self.assertNoHolidayName(name, range(self.start_year, 1993))
+        obs_dts = (
+            "2015-10-05",
+            "2020-10-05",
+        )
+        self.assertHolidayName(f"{name} (ponte)", obs_dts)
+        self.assertNoNonObservedHoliday(obs_dts)
 
     def test_family_day(self):
+        name = "Dia da Família"
         self.assertHolidayName(
-            "Dia da Família",
+            name,
             (f"{year}-12-25" for year in self.full_range),
         )
-
-    def test_observed(self):
-        dt = (
-            "2011-05-02",
-            "2011-09-26",
+        obs_dts = (
             "2011-12-26",
-            "2012-01-02",
-            "2013-02-04",
-            "2013-04-08",
-            "2014-09-08",
-            "2015-10-05",
-            "2016-05-02",
-            "2016-09-26",
             "2016-12-26",
-            "2017-01-02",
-            "2017-06-26",
-            "2019-02-04",
-            "2019-04-08",
-            "2020-10-05",
-            "2022-05-02",
-            "2022-09-26",
             "2022-12-26",
-            "2023-01-02",
-            "2023-06-26",
         )
-        self.assertHoliday(dt)
-        self.assertNoNonObservedHoliday(dt)
+        self.assertHolidayName(f"{name} (ponte)", obs_dts)
+        self.assertNoNonObservedHoliday(obs_dts)
 
     def test_l10n_default(self):
         self.assertLocalizedHolidays(

--- a/tests/countries/test_mozambique.py
+++ b/tests/countries/test_mozambique.py
@@ -19,25 +19,64 @@ from tests.common import CommonCountryTests
 class TestMozambique(CommonCountryTests, TestCase):
     @classmethod
     def setUpClass(cls):
-        super().setUpClass(Mozambique, years=range(1975, 2050))
+        super().setUpClass(Mozambique)
 
-    def test_holidays(self):
-        for year in range(1975, 2050):
-            self.assertHoliday(
-                f"{year}-01-01",
-                f"{year}-02-03",
-                f"{year}-04-07",
-                f"{year}-05-01",
-                f"{year}-06-25",
-                f"{year}-09-07",
-                f"{year}-09-25",
-                f"{year}-12-25",
-            )
+    def test_new_years_day(self):
+        self.assertHolidayName(
+            "Dia da Fraternidade universal",
+            (f"{year}-01-01" for year in self.full_range), 
+        )
 
-        self.assertNoHoliday(f"{year}-10-04" for year in range(1975, 1993))
-        self.assertNoHolidayName("Dia da Paz e Reconciliação", range(1975, 1993))
-        self.assertHoliday(f"{year}-10-04" for year in range(1993, 2050))
+    def test_heroes_day(self):
+        self.assertHolidayName(
+            "Dia dos Heróis Moçambicanos",
+            (f"{year}-02-03" for year in self.full_range), 
+        )
+    
+    def test_womens_day(self):
+        self.assertHolidayName(
+            "Dia da Mulher Moçambicana",
+            (f"{year}-04-07" for year in self.full_range), 
+        )
 
+    def test_workers_day(self):
+        self.assertHolidayName(
+            "Dia Internacional dos Trabalhadores",
+            (f"{year}-05-01" for year in self.full_range), 
+        )
+
+    def test_independence_day(self):
+        self.assertHolidayName(
+            "Dia da Independência Nacional",
+            (f"{year}-06-25" for year in self.full_range), 
+        )
+
+    def test_victory_day(self):
+        self.assertHolidayName(
+            "Dia da Vitória",
+            (f"{year}-09-07" for year in self.full_range), 
+        )
+
+    def test_armed_forces_day(self):
+        self.assertHolidayName(
+            "Dia das Forças Armadas de Libertação Nacional",
+            (f"{year}-09-25" for year in self.full_range), 
+        )
+
+    def test_peace_and_reconciliation_day(self):
+        name = "Dia da Paz e Reconciliação"
+        self.assertHolidayName(
+            name,
+            (f"{year}-10-04" for year in range(1993, self.end_year)),
+        )
+        self.assertNoHolidayName(name, range(self.start_year, 1993))
+
+    def test_family_day(self):
+        self.assertHolidayName(
+            "Dia da Família",
+            (f"{year}-12-25" for year in self.full_range), 
+        )
+        
     def test_observed(self):
         dt = (
             "2011-05-02",

--- a/tests/countries/test_mozambique.py
+++ b/tests/countries/test_mozambique.py
@@ -23,10 +23,7 @@ class TestMozambique(CommonCountryTests, TestCase):
 
     def test_new_years_day(self):
         name = "Dia da Fraternidade universal"
-        self.assertHolidayName(
-            name,
-            (f"{year}-01-01" for year in self.full_range),
-        )
+        self.assertHolidayName(name, (f"{year}-01-01" for year in self.full_range))
         obs_dts = (
             "2012-01-02",
             "2017-01-02",

--- a/tests/countries/test_mozambique.py
+++ b/tests/countries/test_mozambique.py
@@ -24,43 +24,43 @@ class TestMozambique(CommonCountryTests, TestCase):
     def test_new_years_day(self):
         self.assertHolidayName(
             "Dia da Fraternidade universal",
-            (f"{year}-01-01" for year in self.full_range), 
+            (f"{year}-01-01" for year in self.full_range),
         )
 
     def test_heroes_day(self):
         self.assertHolidayName(
             "Dia dos Heróis Moçambicanos",
-            (f"{year}-02-03" for year in self.full_range), 
+            (f"{year}-02-03" for year in self.full_range),
         )
-    
+
     def test_womens_day(self):
         self.assertHolidayName(
             "Dia da Mulher Moçambicana",
-            (f"{year}-04-07" for year in self.full_range), 
+            (f"{year}-04-07" for year in self.full_range),
         )
 
     def test_workers_day(self):
         self.assertHolidayName(
             "Dia Internacional dos Trabalhadores",
-            (f"{year}-05-01" for year in self.full_range), 
+            (f"{year}-05-01" for year in self.full_range),
         )
 
     def test_independence_day(self):
         self.assertHolidayName(
             "Dia da Independência Nacional",
-            (f"{year}-06-25" for year in self.full_range), 
+            (f"{year}-06-25" for year in self.full_range),
         )
 
     def test_victory_day(self):
         self.assertHolidayName(
             "Dia da Vitória",
-            (f"{year}-09-07" for year in self.full_range), 
+            (f"{year}-09-07" for year in self.full_range),
         )
 
     def test_armed_forces_day(self):
         self.assertHolidayName(
             "Dia das Forças Armadas de Libertação Nacional",
-            (f"{year}-09-25" for year in self.full_range), 
+            (f"{year}-09-25" for year in self.full_range),
         )
 
     def test_peace_and_reconciliation_day(self):
@@ -74,9 +74,9 @@ class TestMozambique(CommonCountryTests, TestCase):
     def test_family_day(self):
         self.assertHolidayName(
             "Dia da Família",
-            (f"{year}-12-25" for year in self.full_range), 
+            (f"{year}-12-25" for year in self.full_range),
         )
-        
+
     def test_observed(self):
         dt = (
             "2011-05-02",

--- a/tests/countries/test_mozambique.py
+++ b/tests/countries/test_mozambique.py
@@ -97,9 +97,7 @@ class TestMozambique(CommonCountryTests, TestCase):
 
     def test_peace_and_reconciliation_day(self):
         name = "Dia da Paz e Reconciliação"
-        self.assertHolidayName(
-            name, (f"{year}-10-04" for year in range(1993, self.end_year))
-        )
+        self.assertHolidayName(name, (f"{year}-10-04" for year in range(1993, self.end_year)))
         self.assertNoHolidayName(name, range(self.start_year, 1993))
         obs_dts = (
             "2015-10-05",

--- a/tests/countries/test_mozambique.py
+++ b/tests/countries/test_mozambique.py
@@ -23,10 +23,7 @@ class TestMozambique(CommonCountryTests, TestCase):
 
     def test_new_years_day(self):
         name = "Dia da Fraternidade universal"
-        self.assertHolidayName(
-            name,
-            (f"{year}-01-01" for year in self.full_range),
-        )
+        self.assertHolidayName(name, (f"{year}-01-01" for year in self.full_range))
         obs_dts = (
             "2012-01-02",
             "2017-01-02",
@@ -37,10 +34,7 @@ class TestMozambique(CommonCountryTests, TestCase):
 
     def test_heroes_day(self):
         name = "Dia dos Heróis Moçambicanos"
-        self.assertHolidayName(
-            name,
-            (f"{year}-02-03" for year in self.full_range),
-        )
+        self.assertHolidayName(name, (f"{year}-02-03" for year in self.full_range))
         obs_dts = (
             "2013-02-04",
             "2019-02-04",
@@ -50,23 +44,18 @@ class TestMozambique(CommonCountryTests, TestCase):
 
     def test_womens_day(self):
         name = "Dia da Mulher Moçambicana"
-        self.assertHolidayName(
-            name,
-            (f"{year}-04-07" for year in self.full_range),
-        )
+        self.assertHolidayName(name, (f"{year}-04-07" for year in self.full_range))
         obs_dts = (
             "2013-04-08",
             "2019-04-08",
+            "2024-04-08",
         )
         self.assertHolidayName(f"{name} (ponte)", obs_dts)
         self.assertNoNonObservedHoliday(obs_dts)
 
     def test_workers_day(self):
         name = "Dia Internacional dos Trabalhadores"
-        self.assertHolidayName(
-            name,
-            (f"{year}-05-01" for year in self.full_range),
-        )
+        self.assertHolidayName(name, (f"{year}-05-01" for year in self.full_range))
         obs_dts = (
             "2011-05-02",
             "2016-05-02",
@@ -77,10 +66,7 @@ class TestMozambique(CommonCountryTests, TestCase):
 
     def test_independence_day(self):
         name = "Dia da Independência Nacional"
-        self.assertHolidayName(
-            name,
-            (f"{year}-06-25" for year in self.full_range),
-        )
+        self.assertHolidayName(name, (f"{year}-06-25" for year in self.full_range))
         obs_dts = (
             "2017-06-26",
             "2023-06-26",
@@ -90,22 +76,17 @@ class TestMozambique(CommonCountryTests, TestCase):
 
     def test_victory_day(self):
         name = "Dia da Vitória"
-        self.assertHolidayName(
-            name,
-            (f"{year}-09-07" for year in self.full_range),
-        )
+        self.assertHolidayName(name, (f"{year}-09-07" for year in self.full_range))
         obs_dts = (
             "2014-09-08",
+            "2025-09-08",
         )
         self.assertHolidayName(f"{name} (ponte)", obs_dts)
         self.assertNoNonObservedHoliday(obs_dts)
 
     def test_armed_forces_day(self):
         name = "Dia das Forças Armadas de Libertação Nacional"
-        self.assertHolidayName(
-            name,
-            (f"{year}-09-25" for year in self.full_range),
-        )
+        self.assertHolidayName(name, (f"{year}-09-25" for year in self.full_range))
         obs_dts = (
             "2011-09-26",
             "2016-09-26",
@@ -117,8 +98,7 @@ class TestMozambique(CommonCountryTests, TestCase):
     def test_peace_and_reconciliation_day(self):
         name = "Dia da Paz e Reconciliação"
         self.assertHolidayName(
-            name,
-            (f"{year}-10-04" for year in range(1993, self.end_year)),
+            name, (f"{year}-10-04" for year in range(1993, self.end_year))
         )
         self.assertNoHolidayName(name, range(self.start_year, 1993))
         obs_dts = (
@@ -130,10 +110,7 @@ class TestMozambique(CommonCountryTests, TestCase):
 
     def test_family_day(self):
         name = "Dia da Família"
-        self.assertHolidayName(
-            name,
-            (f"{year}-12-25" for year in self.full_range),
-        )
+        self.assertHolidayName(name, (f"{year}-12-25" for year in self.full_range))
         obs_dts = (
             "2011-12-26",
             "2016-12-26",


### PR DESCRIPTION
## Proposed change

Replaces the broad test_holidays() loop with indivitual, per-holiday test methods.
Now, each holiday gets its own dedicated test that uses assertHolidaysName with dynamic year range.
Also ensured that Peace and Reconciliation Day correctly accounts for its 1993 start year.

## Type of change

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [ ] I've run `make check` locally; all checks and tests passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vacanza/holidays/pull/3621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

