### PR TITLE
Update Saudi Arabia holidays

### DIFF
--- a/holidays/countries/saudi_arabia.py
+++ b/holidays/countries/saudi_arabia.py
@@ -137,9 +137,9 @@ class SaudiArabiaIslamicHolidays(_CustomIslamicHolidays):
 class SaudiArabiaStaticHolidays:
     """
     References:
-        [occasion of King Abdullah's return](https://www.arabianbusiness.com/life/saudi-king-return-home-after-hospital-treatment-382456)
+        [Occasion of King Abdullah's return](https://www.arabianbusiness.com/life/saudi-king-return-home-after-hospital-treatment-382456)
         [Day of mourning for King Abdullah](https://web.archive.org/web/20221216055244/https://www.arabnews.com/saudi-arabia/news/694326)
-        [win against Argentina in the World Cup](https://www.bloomberg.com/news/articles/2022-11-23/saudi-arabia-gets-national-holiday-after-beating-argentina-stock-market-closed)
+        [Win against Argentina in the World Cup](https://web.archive.org/web/20250409214752/https://www.theguardian.com/world/2022/nov/22/saudi-arabia-declares-public-holiday-mark-world-cup-win-over-argentina)
     """
 
     special_public_holidays = {

--- a/holidays/countries/saudi_arabia.py
+++ b/holidays/countries/saudi_arabia.py
@@ -14,7 +14,7 @@ from datetime import date
 from gettext import gettext as tr
 
 from holidays.calendars import _CustomIslamicHolidays
-from holidays.calendars.gregorian import JUN, SEP, NOV, THU, FRI, SAT, _timedelta
+from holidays.calendars.gregorian import JAN, FEB, JUN, SEP, NOV, THU, FRI, SAT, _timedelta
 from holidays.groups import IslamicHolidays, StaticHolidays
 from holidays.observed_holiday_base import (
     ObservedHolidayBase,
@@ -135,7 +135,18 @@ class SaudiArabiaIslamicHolidays(_CustomIslamicHolidays):
 
 
 class SaudiArabiaStaticHolidays:
+    """
+    References:
+        [occasion of King Abdullah's return](https://www.arabianbusiness.com/life/saudi-king-return-home-after-hospital-treatment-382456)
+        [Day of mourning for King Abdullah](https://web.archive.org/web/20221216055244/https://www.arabnews.com/saudi-arabia/news/694326)
+        [win against Argentina in the World Cup](https://www.bloomberg.com/news/articles/2022-11-23/saudi-arabia-gets-national-holiday-after-beating-argentina-stock-market-closed)
+    """
+
     special_public_holidays = {
-        # Celebrate the country's win against Argentina in the World Cup.
-        2022: (NOV, 23, tr("يوم وطني")),
+        # A public holiday for King Abdullah's return.
+        2011: (FEB, 26, tr("عطلة رسمية بمناسبة عودة الملك عبد الله")),
+        # Day of mourning for King Abdullah.
+        2015: (JAN, 25, tr("يوم حداد على الملك عبد الله")),
+        # Holiday for the national team's victory in the World Cup.
+        2022: (NOV, 23, tr("عطلة فوز المنتخب في كأس العالم")),
     }

--- a/holidays/countries/saudi_arabia.py
+++ b/holidays/countries/saudi_arabia.py
@@ -137,16 +137,16 @@ class SaudiArabiaIslamicHolidays(_CustomIslamicHolidays):
 class SaudiArabiaStaticHolidays:
     """
     References:
-        [Occasion of King Abdullah's return](https://www.arabianbusiness.com/life/saudi-king-return-home-after-hospital-treatment-382456)
+        [Occasion of King Abdullah's return](https://web.archive.org/web/20130712223303/https://www.arabnews.com/node/369196)
         [Day of mourning for King Abdullah](https://web.archive.org/web/20221216055244/https://www.arabnews.com/saudi-arabia/news/694326)
         [Win against Argentina in the World Cup](https://web.archive.org/web/20250409214752/https://www.theguardian.com/world/2022/nov/22/saudi-arabia-declares-public-holiday-mark-world-cup-win-over-argentina)
     """
 
     special_public_holidays = {
-        # A public holiday for King Abdullah's return.
+        # King Abdullah's Return from Medical Treatment Abroad.
         2011: (FEB, 26, tr("عطلة رسمية بمناسبة عودة الملك عبد الله")),
-        # Day of mourning for King Abdullah.
+        # Day of Mourning for King Abdullah.
         2015: (JAN, 25, tr("يوم حداد على الملك عبد الله")),
-        # Holiday for the national team's victory in the World Cup.
+        # Holiday for the National Team's Victory in the World Cup.
         2022: (NOV, 23, tr("عطلة فوز المنتخب في كأس العالم")),
     }

--- a/holidays/countries/saudi_arabia.py
+++ b/holidays/countries/saudi_arabia.py
@@ -135,7 +135,8 @@ class SaudiArabiaIslamicHolidays(_CustomIslamicHolidays):
 
 
 class SaudiArabiaStaticHolidays:
-    """
+    """Saudi Arabia special holidays.
+
     References:
         [Occasion of King Abdullah's return](https://web.archive.org/web/20130712223303/https://www.arabnews.com/node/369196)
         [Day of mourning for King Abdullah](https://web.archive.org/web/20221216055244/https://www.arabnews.com/saudi-arabia/news/694326)

--- a/holidays/locale/ar/LC_MESSAGES/SA.po
+++ b/holidays/locale/ar/LC_MESSAGES/SA.po
@@ -17,8 +17,8 @@ msgstr ""
 "Project-Id-Version: Holidays 0.99\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2023-08-04 20:02+0300\n"
-"PO-Revision-Date: 2026-06-15 17:02+0530\n"
-"Last-Translator: paresh <194076591+pareshjoshij@users.noreply.github.com>\n"
+"PO-Revision-Date: 2026-06-15 17:43+0000\n"
+"Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: ar\n"
 "MIME-Version: 1.0\n"
@@ -63,14 +63,14 @@ msgstr ""
 msgid "اليوم الوطني"
 msgstr ""
 
-#. A public holiday for King Abdullah's return.
+#. King Abdullah's Return from Medical Treatment Abroad.
 msgid "عطلة رسمية بمناسبة عودة الملك عبد الله"
 msgstr ""
 
-#. Day of mourning for King Abdullah.
+#. Day of Mourning for King Abdullah.
 msgid "يوم حداد على الملك عبد الله"
 msgstr ""
 
-#. Holiday for the national team's victory in the World Cup.
+#. Holiday for the National Team's Victory in the World Cup.
 msgid "عطلة فوز المنتخب في كأس العالم"
 msgstr ""

--- a/holidays/locale/ar/LC_MESSAGES/SA.po
+++ b/holidays/locale/ar/LC_MESSAGES/SA.po
@@ -14,11 +14,11 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.76\n"
+"Project-Id-Version: Holidays 0.99\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2023-08-04 20:02+0300\n"
-"PO-Revision-Date: 2025-06-26 17:55+0300\n"
-"Last-Translator: ~Jhellico <jhellico@gmail.com>\n"
+"PO-Revision-Date: 2026-06-15 17:02+0530\n"
+"Last-Translator: paresh <194076591+pareshjoshij@users.noreply.github.com>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: ar\n"
 "MIME-Version: 1.0\n"
@@ -63,6 +63,14 @@ msgstr ""
 msgid "اليوم الوطني"
 msgstr ""
 
-#. Celebrate the country's win against Argentina in the World Cup.
-msgid "يوم وطني"
+#. A public holiday for King Abdullah's return.
+msgid "عطلة رسمية بمناسبة عودة الملك عبد الله"
+msgstr ""
+
+#. Day of mourning for King Abdullah.
+msgid "يوم حداد على الملك عبد الله"
+msgstr ""
+
+#. Holiday for the national team's victory in the World Cup.
+msgid "عطلة فوز المنتخب في كأس العالم"
 msgstr ""

--- a/holidays/locale/ar/LC_MESSAGES/SA.po
+++ b/holidays/locale/ar/LC_MESSAGES/SA.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.99\n"
+"Project-Id-Version: Holidays 0.100\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2023-08-04 20:02+0300\n"
 "PO-Revision-Date: 2026-06-15 17:43+0000\n"

--- a/holidays/locale/bn/LC_MESSAGES/SA.po
+++ b/holidays/locale/bn/LC_MESSAGES/SA.po
@@ -14,11 +14,11 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.94\n"
+"Project-Id-Version: Holidays 0.99\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2026-04-03 13:41+0400\n"
-"PO-Revision-Date: 2026-04-03 17:55+0400\n"
-"Last-Translator: Shaon Ahamed <shaonahmed8788@gmail.com>\n"
+"PO-Revision-Date: 2026-06-15 17:02+0530\n"
+"Last-Translator: paresh <194076591+pareshjoshij@users.noreply.github.com>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: bn\n"
 "MIME-Version: 1.0\n"
@@ -63,6 +63,14 @@ msgstr "প্রতিষ্ঠা দিবস"
 msgid "اليوم الوطني"
 msgstr "জাতীয় দিবস"
 
-#. Celebrate the country's win against Argentina in the World Cup.
-msgid "يوم وطني"
-msgstr "জাতীয় দিবস (আর্জেন্টিনার বিরুদ্ধে জয় উপলক্ষে)"
+#. A public holiday for King Abdullah's return.
+msgid "عطلة رسمية بمناسبة عودة الملك عبد الله"
+msgstr "রাজা আবদুল্লাহর প্রত্যাবর্তন উপলক্ষে সরকারি ছুটি"
+
+#. Day of mourning for King Abdullah.
+msgid "يوم حداد على الملك عبد الله"
+msgstr "রাজা আবদুল্লাহর জন্য শোক দিবস"
+
+#. Holiday for the national team's victory in the World Cup.
+msgid "عطلة فوز المنتخب في كأس العالم"
+msgstr "বিশ্বকাপে জাতীয় দলের জয়ের ছুটি"

--- a/holidays/locale/bn/LC_MESSAGES/SA.po
+++ b/holidays/locale/bn/LC_MESSAGES/SA.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.99\n"
+"Project-Id-Version: Holidays 0.100\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2026-04-03 13:41+0400\n"
 "PO-Revision-Date: 2026-06-15 17:43+0000\n"

--- a/holidays/locale/bn/LC_MESSAGES/SA.po
+++ b/holidays/locale/bn/LC_MESSAGES/SA.po
@@ -17,8 +17,8 @@ msgstr ""
 "Project-Id-Version: Holidays 0.99\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2026-04-03 13:41+0400\n"
-"PO-Revision-Date: 2026-06-15 17:02+0530\n"
-"Last-Translator: paresh <194076591+pareshjoshij@users.noreply.github.com>\n"
+"PO-Revision-Date: 2026-06-15 17:43+0000\n"
+"Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: bn\n"
 "MIME-Version: 1.0\n"
@@ -63,14 +63,14 @@ msgstr "প্রতিষ্ঠা দিবস"
 msgid "اليوم الوطني"
 msgstr "জাতীয় দিবস"
 
-#. A public holiday for King Abdullah's return.
+#. King Abdullah's Return from Medical Treatment Abroad.
 msgid "عطلة رسمية بمناسبة عودة الملك عبد الله"
 msgstr "রাজা আবদুল্লাহর প্রত্যাবর্তন উপলক্ষে সরকারি ছুটি"
 
-#. Day of mourning for King Abdullah.
+#. Day of Mourning for King Abdullah.
 msgid "يوم حداد على الملك عبد الله"
 msgstr "রাজা আবদুল্লাহর জন্য শোক দিবস"
 
-#. Holiday for the national team's victory in the World Cup.
+#. Holiday for the National Team's Victory in the World Cup.
 msgid "عطلة فوز المنتخب في كأس العالم"
 msgstr "বিশ্বকাপে জাতীয় দলের জয়ের ছুটি"

--- a/holidays/locale/en_US/LC_MESSAGES/SA.po
+++ b/holidays/locale/en_US/LC_MESSAGES/SA.po
@@ -17,8 +17,8 @@ msgstr ""
 "Project-Id-Version: Holidays 0.99\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2023-08-04 20:02+0300\n"
-"PO-Revision-Date: 2026-06-15 17:02+0530\n"
-"Last-Translator: paresh <194076591+pareshjoshij@users.noreply.github.com>\n"
+"PO-Revision-Date: 2026-06-15 17:43+0000\n"
+"Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: en_US\n"
 "MIME-Version: 1.0\n"
@@ -63,14 +63,14 @@ msgstr "Founding Day Holiday"
 msgid "اليوم الوطني"
 msgstr "National Day Holiday"
 
-#. A public holiday for King Abdullah's return.
+#. King Abdullah's Return from Medical Treatment Abroad.
 msgid "عطلة رسمية بمناسبة عودة الملك عبد الله"
-msgstr "A public holiday for King Abdullah's return"
+msgstr "King Abdullah's Return from Medical Treatment Abroad"
 
-#. Day of mourning for King Abdullah.
+#. Day of Mourning for King Abdullah.
 msgid "يوم حداد على الملك عبد الله"
-msgstr "Day of mourning for King Abdullah"
+msgstr "Day of Mourning for King Abdullah"
 
-#. Holiday for the national team's victory in the World Cup.
+#. Holiday for the National Team's Victory in the World Cup.
 msgid "عطلة فوز المنتخب في كأس العالم"
-msgstr "Holiday for the national team's victory in the World Cup"
+msgstr "Holiday for the National Team's Victory in the World Cup"

--- a/holidays/locale/en_US/LC_MESSAGES/SA.po
+++ b/holidays/locale/en_US/LC_MESSAGES/SA.po
@@ -14,11 +14,11 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.76\n"
+"Project-Id-Version: Holidays 0.99\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2023-08-04 20:02+0300\n"
-"PO-Revision-Date: 2025-06-26 17:55+0300\n"
-"Last-Translator: ~Jhellico <jhellico@gmail.com>\n"
+"PO-Revision-Date: 2026-06-15 17:02+0530\n"
+"Last-Translator: paresh <194076591+pareshjoshij@users.noreply.github.com>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: en_US\n"
 "MIME-Version: 1.0\n"
@@ -63,6 +63,14 @@ msgstr "Founding Day Holiday"
 msgid "اليوم الوطني"
 msgstr "National Day Holiday"
 
-#. Celebrate the country's win against Argentina in the World Cup.
-msgid "يوم وطني"
-msgstr "A National Day"
+#. A public holiday for King Abdullah's return.
+msgid "عطلة رسمية بمناسبة عودة الملك عبد الله"
+msgstr "A public holiday for King Abdullah's return"
+
+#. Day of mourning for King Abdullah.
+msgid "يوم حداد على الملك عبد الله"
+msgstr "Day of mourning for King Abdullah"
+
+#. Holiday for the national team's victory in the World Cup.
+msgid "عطلة فوز المنتخب في كأس العالم"
+msgstr "Holiday for the national team's victory in the World Cup"

--- a/holidays/locale/en_US/LC_MESSAGES/SA.po
+++ b/holidays/locale/en_US/LC_MESSAGES/SA.po
@@ -14,7 +14,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Holidays 0.99\n"
+"Project-Id-Version: Holidays 0.100\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2023-08-04 20:02+0300\n"
 "PO-Revision-Date: 2026-06-15 17:43+0000\n"

--- a/tests/countries/test_saudi_arabia.py
+++ b/tests/countries/test_saudi_arabia.py
@@ -23,7 +23,11 @@ class TestSaudiArabia(CommonCountryTests, TestCase):
         super().setUpClass(SaudiArabia, years=years, years_non_observed=years)
 
     def test_special_holidays(self):
-        self.assertHoliday("2022-11-23")
+        self.assertHoliday(
+            "2011-02-26",
+            "2015-01-25",
+            "2022-11-23",
+        )
 
     def test_eid_al_fitr(self):
         name = "عطلة عيد الفطر"
@@ -193,7 +197,7 @@ class TestSaudiArabia(CommonCountryTests, TestCase):
             ("2022-07-13", "عطلة عيد الأضحى (يوم تعويضي)"),
             ("2022-09-22", "اليوم الوطني (يوم تعويضي)"),
             ("2022-09-23", "اليوم الوطني"),
-            ("2022-11-23", "يوم وطني"),
+            ("2022-11-23", "عطلة فوز المنتخب في كأس العالم"),
         )
 
     def test_l10n_default(self):


### PR DESCRIPTION
This PR adds missing historical ad-hoc holidays for Saudi Arabia and corrects the name of an existing one.

### Added
* **2011:** A public holiday for King Abdullah's return from medical treatment abroad (February 26).
* **2015:** Day of mourning for King Abdullah and pledge of allegiance to King Salman (January 25).

### Modified
* **2022:** Corrected the translation and name of the World Cup victory holiday (November 23). It was previously incorrectly labeled as a generic "National Day" (`يوم وطني`), 
<img width="643" height="370" alt="Capture" src="https://github.com/user-attachments/assets/c947a6af-9d79-4ca2-b1f4-6ac482587230" />

* and is now accurately named "Holiday for the national team's victory in the World Cup" (`عطلة فوز المنتخب في كأس العالم`).

**Note:** I have zero knowledge of the Bengali (`bn`) and Arabic (`ar`) languages. All translations included in this PR were generated with the help of translation tools.


- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
