### PR TITLE
Update README.md: Added `uv` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,22 +44,65 @@ specific date is a holiday as fast and flexible as possible.
   </tr>
 </table>
 
-## Install
+## Installation & execution
 
-The latest stable version can always be installed or updated via pip:
+The `holidays` package can be installed and run using either `pip` or `uv`.
 
-``` shell
+### Using pip
+
+#### Installation
+
+Install or update the latest stable version via pip:
+
+```shell
 pip install --upgrade holidays
+
 ```
 
-The latest development (dev) version can be installed directly from GitHub:
+To try out the latest features, install the development version directly from GitHub:
 
-``` shell
+```shell
 pip install --upgrade https://github.com/vacanza/holidays/tarball/dev
+
 ```
 
-All new features are always first pushed to dev branch, then released on main branch upon official
-version upgrades.
+> **Note:** New features are pushed to the `dev` branch first, then merged into `main` for official releases.
+
+#### Quick Run
+
+Generate a calendar file using the built-in CLI utility:
+
+```shell
+python3 -m holidays.generate_ics US
+
+```
+
+### Using uv
+
+If you prefer using [uv](https://docs.astral.sh/uv/), you can run the library instantly without an explicit global installation.
+
+
+#### One-off Execution
+
+Generate a calendar file directly using `uvx`:
+
+```shell
+uvx --from holidays holidays-ics US
+
+```
+
+#### Interactive & Script Usage
+
+To drop into a Python REPL or run a local script with `holidays` available on the fly:
+
+```shell
+# Open an interactive Python shell
+uvx --with holidays python3
+
+# Run a specific script
+uvx --with holidays python3 script.py
+
+```
 
 ## Documentation
 


### PR DESCRIPTION
## Proposed change

* There is an inconsistency in the documentation: the [GitHub README](https://github.com/vacanza/holidays/blob/dev/README.md#install) states that pip should be used but does not mention uv. Conversely, the [ReadTheDocs Examples](https://holidays.readthedocs.io/en/latest/examples/) page recommends using uv instead of pip. We should align these to avoid confusing users.
* On Debian and Ubuntu distributions, `pip` is not pre-installed, and `pip3` requires manual installation along with the `--break-system-packages` flag to run. Using `uv` bypasses these hurdles completely with a simple, hassle-free installation.

Partially fixes:
* https://github.com/vacanza/holidays/issues/3670

Your PR description goes here.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [ ] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
