### PR TITLE
Add SIX Swiss Exchange (SIX) holidays

### DIFF
--- a/README.md
+++ b/README.md
@@ -2038,6 +2038,13 @@ code when available. The following financial markets are available:
 <td></td>
 </tr>
 <tr>
+<td>SIX Swiss Exchange</td>
+<td>XSWX</td>
+<td>SIX Swiss Exchange market holidays</td>
+<td><strong>de</strong>, en_US, fr, it, th, uk</td>
+<td></td>
+</tr>
+<tr>
 <td>Toronto Stock Exchange</td>
 <td>XTSE</td>
 <td>Toronto Stock Exchange (TSX) market holidays</td>

--- a/holidays/countries/jersey.py
+++ b/holidays/countries/jersey.py
@@ -18,8 +18,8 @@ from holidays.observed_holiday_base import (
     ObservedHolidayBase,
     SAT_SUN_TO_NEXT_WORKDAY,
     SUN_TO_NEXT_WORKDAY,
-    SAT_TO_NONE,
     SUN_TO_NONE,
+    SAT_SUN_TO_NONE,
 )
 
 
@@ -145,7 +145,7 @@ class Jersey(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         self._add_observed(
             # Liberation Day
             self._add_holiday_may_9("Liberation Day"),
-            rule=SAT_TO_NONE + SUN_TO_NONE if self._year <= 2010 else SUN_TO_NONE,
+            rule=SAT_SUN_TO_NONE if self._year <= 2010 else SUN_TO_NONE,
         )
 
 

--- a/holidays/countries/macau.py
+++ b/holidays/countries/macau.py
@@ -24,8 +24,7 @@ from holidays.observed_holiday_base import (
     ObservedHolidayBase,
     SUN_TO_NEXT_WORKDAY,
     SAT_SUN_TO_NEXT_WORKDAY,
-    SAT_TO_NONE,
-    SUN_TO_NONE,
+    SAT_SUN_TO_NONE,
 )
 
 
@@ -358,7 +357,7 @@ class Macau(
             self._move_holiday(
                 # New Year's Eve.
                 self._add_new_years_eve(self._format_holiday_name(begin_time_label, tr("除夕"))),
-                rule=SAT_TO_NONE + SUN_TO_NONE,
+                rule=SAT_SUN_TO_NONE,
             )
 
         if self.observed:

--- a/holidays/countries/switzerland.py
+++ b/holidays/countries/switzerland.py
@@ -44,7 +44,7 @@ class Switzerland(ObservedHolidayBase, ChristianHolidays, InternationalHolidays)
     country = "CH"
     default_language = "de"
     start_year = 1801
-    subdivisions = (
+    subdivisions: tuple[str, ...] = (
         # Cantons.
         "AG",  # Aargau.
         "AI",  # Appenzell Innerrhoden.
@@ -111,7 +111,7 @@ class Switzerland(ObservedHolidayBase, ChristianHolidays, InternationalHolidays)
         # Cities.
         "Stadt Zürich": "Stadt Zurich",
     }
-    supported_categories = (DE_FACTO, HALF_DAY, OPTIONAL, PUBLIC)
+    supported_categories: tuple[str, ...] = (DE_FACTO, HALF_DAY, OPTIONAL, PUBLIC)
     supported_languages = ("de", "en_US", "fr", "it", "th", "uk")
 
     def __init__(self, *args, **kwargs):

--- a/holidays/countries/switzerland.py
+++ b/holidays/countries/switzerland.py
@@ -20,7 +20,7 @@ from holidays.observed_holiday_base import (
     MON_ONLY,
     TUE_TO_NONE,
     SAT_TO_NONE,
-    SUN_TO_NONE,
+    SAT_SUN_TO_NONE,
     ALL_TO_NEXT_MON,
 )
 
@@ -811,10 +811,10 @@ class Switzerland(ObservedHolidayBase, ChristianHolidays, InternationalHolidays)
 
         # Bridge Holiday.
         name = tr("Brückentag")
-        self._add_observed(self._add_holiday_dec_27(name), rule=SAT_TO_NONE + SUN_TO_NONE)
-        self._add_observed(self._add_holiday_dec_28(name), rule=SAT_TO_NONE + SUN_TO_NONE)
-        self._add_observed(self._add_holiday_dec_29(name), rule=SAT_TO_NONE + SUN_TO_NONE)
-        self._add_observed(self._add_holiday_dec_30(name), rule=SAT_TO_NONE + SUN_TO_NONE)
+        self._add_observed(self._add_holiday_dec_27(name), rule=SAT_SUN_TO_NONE)
+        self._add_observed(self._add_holiday_dec_28(name), rule=SAT_SUN_TO_NONE)
+        self._add_observed(self._add_holiday_dec_29(name), rule=SAT_SUN_TO_NONE)
+        self._add_observed(self._add_holiday_dec_30(name), rule=SAT_SUN_TO_NONE)
 
     @property
     def _vernal_equinox_date(self) -> tuple[int, int]:

--- a/holidays/financial/__init__.py
+++ b/holidays/financial/__init__.py
@@ -28,4 +28,5 @@ from holidays.financial.national_stock_exchange_of_india import (
 from holidays.financial.ny_stock_exchange import NewYorkStockExchange, XNYS, NYSE
 from holidays.financial.shanghai_stock_exchange import ShanghaiStockExchange, XSHG, SSE
 from holidays.financial.shenzhen_stock_exchange import ShenzhenStockExchange, XSHE, SZSE
+from holidays.financial.six_swiss_exchange import SIXSwissExchange, XSWX, SIX
 from holidays.financial.toronto_stock_exchange import TorontoStockExchange, XTSE, TSX

--- a/holidays/financial/bolsa_mexicana_de_valores.py
+++ b/holidays/financial/bolsa_mexicana_de_valores.py
@@ -14,7 +14,7 @@ from gettext import gettext as tr
 
 from holidays.calendars.gregorian import SEP
 from holidays.groups import ChristianHolidays, InternationalHolidays, StaticHolidays
-from holidays.observed_holiday_base import ObservedHolidayBase, SAT_TO_NONE, SUN_TO_NONE
+from holidays.observed_holiday_base import ObservedHolidayBase, SAT_SUN_TO_NONE
 
 
 class BolsaMexicanaDeValores(
@@ -63,7 +63,7 @@ class BolsaMexicanaDeValores(
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, BolsaMexicanaDeValoresStaticHolidays)
-        kwargs.setdefault("observed_rule", SAT_TO_NONE + SUN_TO_NONE)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NONE)
         super().__init__(*args, **kwargs)
 
     def _populate_public_holidays(self):

--- a/holidays/financial/national_stock_exchange_of_india.py
+++ b/holidays/financial/national_stock_exchange_of_india.py
@@ -20,7 +20,7 @@ from holidays.groups import (
     IslamicHolidays,
     StaticHolidays,
 )
-from holidays.observed_holiday_base import ObservedHolidayBase, SAT_TO_NONE, SUN_TO_NONE
+from holidays.observed_holiday_base import ObservedHolidayBase, SAT_SUN_TO_NONE
 
 
 class NationalStockExchangeOfIndia(
@@ -85,7 +85,7 @@ class NationalStockExchangeOfIndia(
             calendar_delta_days=+1,
         )
         StaticHolidays.__init__(self, cls=NationalStockExchangeOfIndiaStaticHolidays)
-        kwargs.setdefault("observed_rule", SAT_TO_NONE + SUN_TO_NONE)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NONE)
         super().__init__(*args, **kwargs)
 
     def _populate_public_holidays(self):

--- a/holidays/financial/six_swiss_exchange.py
+++ b/holidays/financial/six_swiss_exchange.py
@@ -18,15 +18,16 @@ from holidays.mixins.child_entity import ChildEntity
 from holidays.observed_holiday_base import SAT_TO_NONE, SUN_TO_NONE
 
 
-class SIXSwissExchange(ChildEntity, Switzerland):  # type: ignore[assignment, misc]
-    """SIX Swiss Exchange holidays.
+class SIXSwissExchange(ChildEntity, Switzerland):
+    """SIX Swiss Exchange (SIX) holidays.
 
     References:
         [2018](https://web.archive.org/web/20260712044834/https://www.six-group.com/dam/download/sites/education/preparatory-documentation/trading-module/trading-guide.pdf)
         [2019](https://web.archive.org/web/20260712044834/https://www.six-group.com/dam/download/sites/education/preparatory-documentation/trading-module/trading-guide.pdf)
+        [2021](https://web.archive.org/web/20211102133818/https://www.six-group.com/dam/download/the-swiss-stock-exchange/trading/trading-provisions/regulation/trading-guides/trading-calendar-2021.pdf)
         [2022](https://web.archive.org/web/20220420104843/https://www.six-group.com/dam/download/the-swiss-stock-exchange/trading/trading-provisions/regulation/trading-guides/trading-calendar-2022.pdf)
         [2023](https://web.archive.org/web/20220626051815/https://www.six-group.com/dam/download/the-swiss-stock-exchange/trading/trading-provisions/regulation/trading-guides/trading-calendar-2023.pdf)
-        [2024](https://web.archive.org/web/20240910205011/https://www.six-group.com/en/market-data/news-tools/trading-currency-holiday-calendar.html#/#/)
+        [2024](https://web.archive.org/web/20240521040627/https://www.six-group.com/dam/download/the-swiss-stock-exchange/trading/trading-provisions/regulation/trading-guides/trading-calendar-2024.pdf)
         [2025](https://web.archive.org/web/20250908065713/https://www.six-group.com/dam/download/the-swiss-stock-exchange/trading/trading-provisions/regulation/trading-guides/trading-calendar-2025.pdf)
         [2026](https://web.archive.org/web/20251225182641/https://www.six-group.com/dam/download/the-swiss-stock-exchange/trading/trading-provisions/regulation/trading-guides/trading-calendar-2026.pdf)
     """
@@ -35,10 +36,8 @@ class SIXSwissExchange(ChildEntity, Switzerland):  # type: ignore[assignment, mi
     market = "XSWX"
     parent_entity = Switzerland
     parent_entity_subdivision_code = "ZH"
-    supported_categories = (PUBLIC,)  # type: ignore[assignment]
+    supported_categories: tuple[str] = (PUBLIC,)
     start_year = 2000
-
-    _weekend_to_none_rule = SAT_TO_NONE + SUN_TO_NONE
 
     def _populate_public_holidays(self) -> None:
         super()._populate_public_holidays()
@@ -58,7 +57,9 @@ class SIXSwissExchange(ChildEntity, Switzerland):  # type: ignore[assignment, mi
         if self.observed:
             for dt in tuple(self.keys()):
                 if dt.year == year:
-                    self._move_holiday_forced(dt, rule=self._weekend_to_none_rule)
+                    self._move_holiday(
+                        dt, rule=SAT_TO_NONE + SUN_TO_NONE, show_observed_label=False
+                    )
 
 
 class XSWX(SIXSwissExchange):

--- a/holidays/financial/six_swiss_exchange.py
+++ b/holidays/financial/six_swiss_exchange.py
@@ -43,7 +43,7 @@ class SIXSwissExchange(ChildEntity, Switzerland):  # type: ignore[assignment, mi
     def _populate_public_holidays(self) -> None:
         super()._populate_public_holidays()
 
-        # Saint Berchtold's Day
+        # Saint Berchtold's Day.
         self._add_new_years_day_two(tr("Berchtoldstag"))
 
         # Christmas Eve.

--- a/holidays/financial/six_swiss_exchange.py
+++ b/holidays/financial/six_swiss_exchange.py
@@ -15,7 +15,7 @@ from gettext import gettext as tr
 from holidays.constants import PUBLIC
 from holidays.countries.switzerland import Switzerland
 from holidays.mixins.child_entity import ChildEntity
-from holidays.observed_holiday_base import SAT_TO_NONE, SUN_TO_NONE
+from holidays.observed_holiday_base import SAT_SUN_TO_NONE
 
 
 class SIXSwissExchange(ChildEntity, Switzerland):
@@ -57,9 +57,7 @@ class SIXSwissExchange(ChildEntity, Switzerland):
         if self.observed:
             for dt in tuple(self.keys()):
                 if dt.year == year:
-                    self._move_holiday(
-                        dt, rule=SAT_TO_NONE + SUN_TO_NONE, show_observed_label=False
-                    )
+                    self._move_holiday(dt, rule=SAT_SUN_TO_NONE, show_observed_label=False)
 
 
 class XSWX(SIXSwissExchange):

--- a/holidays/financial/six_swiss_exchange.py
+++ b/holidays/financial/six_swiss_exchange.py
@@ -10,12 +10,12 @@
 #  Website: https://github.com/vacanza/holidays
 #  License: MIT (see LICENSE file)
 
+from datetime import date
 from gettext import gettext as tr
 
 from holidays.constants import PUBLIC
 from holidays.countries.switzerland import Switzerland
 from holidays.mixins.child_entity import ChildEntity
-from holidays.observed_holiday_base import SAT_SUN_TO_NONE
 
 
 class SIXSwissExchange(ChildEntity, Switzerland):
@@ -39,6 +39,13 @@ class SIXSwissExchange(ChildEntity, Switzerland):
     supported_categories: tuple[str] = (PUBLIC,)
     start_year = 2000
 
+    def _add_holiday(self, name: str, *args) -> date | None:
+        dt = args if len(args) > 1 else args[0]
+        dt = dt if isinstance(dt, date) else date(self._year, *dt)
+        if self._is_weekend(dt):
+            return None
+        return super()._add_holiday(name, dt)
+
     def _populate_public_holidays(self) -> None:
         super()._populate_public_holidays()
 
@@ -50,14 +57,6 @@ class SIXSwissExchange(ChildEntity, Switzerland):
 
         # New Year's Eve.
         self._add_new_years_eve(tr("Vortag vor Neujahr"))
-
-    def _populate(self, year: int) -> None:
-        super()._populate(year)
-
-        if self.observed:
-            for dt in tuple(self.keys()):
-                if dt.year == year:
-                    self._move_holiday(dt, rule=SAT_SUN_TO_NONE, show_observed_label=False)
 
 
 class XSWX(SIXSwissExchange):

--- a/holidays/financial/six_swiss_exchange.py
+++ b/holidays/financial/six_swiss_exchange.py
@@ -1,0 +1,69 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see CONTRIBUTORS file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/holidays
+#  License: MIT (see LICENSE file)
+
+from gettext import gettext as tr
+
+from holidays.constants import PUBLIC
+from holidays.countries.switzerland import Switzerland
+from holidays.mixins.child_entity import ChildEntity
+from holidays.observed_holiday_base import SAT_TO_NONE, SUN_TO_NONE
+
+
+class SIXSwissExchange(ChildEntity, Switzerland):  # type: ignore[assignment, misc]
+    """SIX Swiss Exchange holidays.
+
+    References:
+        [2018](https://web.archive.org/web/20260712044834/https://www.six-group.com/dam/download/sites/education/preparatory-documentation/trading-module/trading-guide.pdf)
+        [2019](https://web.archive.org/web/20260712044834/https://www.six-group.com/dam/download/sites/education/preparatory-documentation/trading-module/trading-guide.pdf)
+        [2022](https://web.archive.org/web/20220420104843/https://www.six-group.com/dam/download/the-swiss-stock-exchange/trading/trading-provisions/regulation/trading-guides/trading-calendar-2022.pdf)
+        [2023](https://web.archive.org/web/20220626051815/https://www.six-group.com/dam/download/the-swiss-stock-exchange/trading/trading-provisions/regulation/trading-guides/trading-calendar-2023.pdf)
+        [2024](https://web.archive.org/web/20240910205011/https://www.six-group.com/en/market-data/news-tools/trading-currency-holiday-calendar.html#/#/)
+        [2025](https://web.archive.org/web/20250908065713/https://www.six-group.com/dam/download/the-swiss-stock-exchange/trading/trading-provisions/regulation/trading-guides/trading-calendar-2025.pdf)
+        [2026](https://web.archive.org/web/20251225182641/https://www.six-group.com/dam/download/the-swiss-stock-exchange/trading/trading-provisions/regulation/trading-guides/trading-calendar-2026.pdf)
+    """
+
+    country = None  # type: ignore[assignment]
+    market = "XSWX"
+    parent_entity = Switzerland
+    parent_entity_subdivision_code = "ZH"
+    supported_categories = (PUBLIC,)  # type: ignore[assignment]
+    start_year = 2000
+
+    _weekend_to_none_rule = SAT_TO_NONE + SUN_TO_NONE
+
+    def _populate_public_holidays(self) -> None:
+        super()._populate_public_holidays()
+
+        # Saint Berchtold's Day
+        self._add_new_years_day_two(tr("Berchtoldstag"))
+
+        # Christmas Eve.
+        self._add_christmas_eve(tr("Heiligabend"))
+
+        # New Year's Eve.
+        self._add_new_years_eve(tr("Vortag vor Neujahr"))
+
+    def _populate(self, year: int) -> None:
+        super()._populate(year)
+
+        if self.observed:
+            for dt in tuple(self.keys()):
+                if dt.year == year:
+                    self._move_holiday_forced(dt, rule=self._weekend_to_none_rule)
+
+
+class XSWX(SIXSwissExchange):
+    pass
+
+
+class SIX(SIXSwissExchange):
+    pass

--- a/holidays/financial/toronto_stock_exchange.py
+++ b/holidays/financial/toronto_stock_exchange.py
@@ -20,8 +20,7 @@ from holidays.observed_holiday_base import (
     SAT_SUN_TO_NEXT_MON_TUE,
     SAT_SUN_TO_NEXT_MON,
     MON_TO_NEXT_TUE,
-    SAT_TO_NONE,
-    SUN_TO_NONE,
+    SAT_SUN_TO_NONE,
 )
 
 
@@ -118,7 +117,7 @@ class TorontoStockExchange(
         self._move_holiday(
             # Christmas Eve.
             self._add_christmas_eve(self._format_holiday_name(pause_label, tr("Christmas Eve"))),
-            rule=SAT_TO_NONE + SUN_TO_NONE,
+            rule=SAT_SUN_TO_NONE,
         )
 
 

--- a/holidays/locale/de/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/de/LC_MESSAGES/XSWX.po
@@ -17,7 +17,7 @@ msgstr ""
 "Project-Id-Version: Holidays 0.101\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2026-07-11 00:25+0000\n"
-"PO-Revision-Date: 2026-07-12 12:10+0000\n"
+"PO-Revision-Date: 2026-07-12 13:15+0000\n"
 "Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: de\n"
@@ -27,7 +27,7 @@ msgstr ""
 "Generated-By: Lingva 5.0.6\n"
 "X-Source-Language: de\n"
 
-#. Saint Berchtold's Day
+#. Saint Berchtold's Day.
 msgid "Berchtoldstag"
 msgstr ""
 

--- a/holidays/locale/de/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/de/LC_MESSAGES/XSWX.po
@@ -10,7 +10,7 @@
 #  Website: https://github.com/vacanza/holidays
 #  License: MIT (see LICENSE file)
 #
-# SIX Swiss Exchange holidays.
+# SIX Swiss Exchange (SIX) holidays.
 #
 msgid ""
 msgstr ""

--- a/holidays/locale/de/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/de/LC_MESSAGES/XSWX.po
@@ -1,0 +1,40 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see CONTRIBUTORS file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/holidays
+#  License: MIT (see LICENSE file)
+#
+# SIX Swiss Exchange holidays.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Holidays 0.101\n"
+"Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
+"POT-Creation-Date: 2026-07-11 00:25+0000\n"
+"PO-Revision-Date: 2026-07-12 12:10+0000\n"
+"Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
+"Language-Team: Holidays Localization Team\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Lingva 5.0.6\n"
+"X-Source-Language: de\n"
+
+#. Saint Berchtold's Day
+msgid "Berchtoldstag"
+msgstr ""
+
+#. Christmas Eve.
+msgid "Heiligabend"
+msgstr ""
+
+#. New Year's Eve.
+msgid "Vortag vor Neujahr"
+msgstr ""

--- a/holidays/locale/en_US/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/en_US/LC_MESSAGES/XSWX.po
@@ -10,7 +10,7 @@
 #  Website: https://github.com/vacanza/holidays
 #  License: MIT (see LICENSE file)
 #
-# SIX Swiss Exchange holidays en_US localization.
+# SIX Swiss Exchange (SIX) holidays en_US localization.
 #
 msgid ""
 msgstr ""

--- a/holidays/locale/en_US/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/en_US/LC_MESSAGES/XSWX.po
@@ -17,7 +17,7 @@ msgstr ""
 "Project-Id-Version: Holidays 0.101\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2026-07-11 00:25+0000\n"
-"PO-Revision-Date: 2026-07-12 12:10+0000\n"
+"PO-Revision-Date: 2026-07-12 13:15+0000\n"
 "Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: en_US\n"
@@ -27,7 +27,7 @@ msgstr ""
 "Generated-By: Lingva 5.0.6\n"
 "X-Source-Language: de\n"
 
-#. Saint Berchtold's Day
+#. Saint Berchtold's Day.
 msgid "Berchtoldstag"
 msgstr "Saint Berchtold's Day"
 

--- a/holidays/locale/en_US/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/en_US/LC_MESSAGES/XSWX.po
@@ -1,0 +1,40 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see CONTRIBUTORS file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/holidays
+#  License: MIT (see LICENSE file)
+#
+# SIX Swiss Exchange holidays en_US localization.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Holidays 0.101\n"
+"Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
+"POT-Creation-Date: 2026-07-11 00:25+0000\n"
+"PO-Revision-Date: 2026-07-12 12:10+0000\n"
+"Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
+"Language-Team: Holidays Localization Team\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Lingva 5.0.6\n"
+"X-Source-Language: de\n"
+
+#. Saint Berchtold's Day
+msgid "Berchtoldstag"
+msgstr "Saint Berchtold's Day"
+
+#. Christmas Eve.
+msgid "Heiligabend"
+msgstr "Christmas Eve"
+
+#. New Year's Eve.
+msgid "Vortag vor Neujahr"
+msgstr "New Year's Eve"

--- a/holidays/locale/fr/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/fr/LC_MESSAGES/XSWX.po
@@ -17,8 +17,8 @@ msgstr ""
 "Project-Id-Version: Holidays 0.101\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2026-07-11 00:25+0000\n"
-"PO-Revision-Date: 2026-07-12 12:10+0000\n"
-"Last-Translator: Paresh Joshi <194076591+pareshjoshij@users.noreply.github.com>\n"
+"PO-Revision-Date: 2026-07-12 13:15+0000\n"
+"Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -27,7 +27,7 @@ msgstr ""
 "Generated-By: Lingva 5.0.6\n"
 "X-Source-Language: de\n"
 
-#. Saint Berchtold's Day
+#. Saint Berchtold's Day.
 msgid "Berchtoldstag"
 msgstr "Saint-Berchtold"
 

--- a/holidays/locale/fr/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/fr/LC_MESSAGES/XSWX.po
@@ -1,0 +1,40 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see CONTRIBUTORS file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/holidays
+#  License: MIT (see LICENSE file)
+#
+# SIX Swiss Exchange holidays fr localization.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Holidays 0.101\n"
+"Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
+"POT-Creation-Date: 2026-07-11 00:25+0000\n"
+"PO-Revision-Date: 2026-07-12 12:10+0000\n"
+"Last-Translator: Paresh Joshi <194076591+pareshjoshij@users.noreply.github.com>\n"
+"Language-Team: Holidays Localization Team\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Lingva 5.0.6\n"
+"X-Source-Language: de\n"
+
+#. Saint Berchtold's Day
+msgid "Berchtoldstag"
+msgstr "Saint-Berchtold"
+
+#. Christmas Eve.
+msgid "Heiligabend"
+msgstr "Veille de Noël"
+
+#. New Year's Eve.
+msgid "Vortag vor Neujahr"
+msgstr "Réveillon de la Saint-Sylvestre"

--- a/holidays/locale/fr/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/fr/LC_MESSAGES/XSWX.po
@@ -10,7 +10,7 @@
 #  Website: https://github.com/vacanza/holidays
 #  License: MIT (see LICENSE file)
 #
-# SIX Swiss Exchange holidays fr localization.
+# SIX Swiss Exchange (SIX) holidays fr localization.
 #
 msgid ""
 msgstr ""

--- a/holidays/locale/it/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/it/LC_MESSAGES/XSWX.po
@@ -10,7 +10,7 @@
 #  Website: https://github.com/vacanza/holidays
 #  License: MIT (see LICENSE file)
 #
-# SIX Swiss Exchange holidays it localization.
+# SIX Swiss Exchange (SIX) holidays it localization.
 #
 msgid ""
 msgstr ""

--- a/holidays/locale/it/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/it/LC_MESSAGES/XSWX.po
@@ -1,0 +1,40 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see CONTRIBUTORS file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/holidays
+#  License: MIT (see LICENSE file)
+#
+# SIX Swiss Exchange holidays it localization.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Holidays 0.101\n"
+"Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
+"POT-Creation-Date: 2026-07-11 00:25+0000\n"
+"PO-Revision-Date: 2026-07-12 12:10+0000\n"
+"Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
+"Language-Team: Holidays Localization Team\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Lingva 5.0.6\n"
+"X-Source-Language: de\n"
+
+#. Saint Berchtold's Day
+msgid "Berchtoldstag"
+msgstr "Giorno di Bertoldo"
+
+#. Christmas Eve.
+msgid "Heiligabend"
+msgstr "Vigilia di Natale"
+
+#. New Year's Eve.
+msgid "Vortag vor Neujahr"
+msgstr "Vigilia di Capodanno"

--- a/holidays/locale/it/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/it/LC_MESSAGES/XSWX.po
@@ -17,7 +17,7 @@ msgstr ""
 "Project-Id-Version: Holidays 0.101\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2026-07-11 00:25+0000\n"
-"PO-Revision-Date: 2026-07-12 12:10+0000\n"
+"PO-Revision-Date: 2026-07-12 13:15+0000\n"
 "Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: it\n"
@@ -27,7 +27,7 @@ msgstr ""
 "Generated-By: Lingva 5.0.6\n"
 "X-Source-Language: de\n"
 
-#. Saint Berchtold's Day
+#. Saint Berchtold's Day.
 msgid "Berchtoldstag"
 msgstr "Giorno di Bertoldo"
 

--- a/holidays/locale/th/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/th/LC_MESSAGES/XSWX.po
@@ -1,0 +1,40 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see CONTRIBUTORS file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/holidays
+#  License: MIT (see LICENSE file)
+#
+# SIX Swiss Exchange holidays th localization.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Holidays 0.101\n"
+"Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
+"POT-Creation-Date: 2026-07-11 00:25+0000\n"
+"PO-Revision-Date: 2026-07-12 12:10+0000\n"
+"Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
+"Language-Team: Holidays Localization Team\n"
+"Language: th\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Lingva 5.0.6\n"
+"X-Source-Language: de\n"
+
+#. Saint Berchtold's Day
+msgid "Berchtoldstag"
+msgstr "วันสมโภชนักบุญแบร์กโทลด์"
+
+#. Christmas Eve.
+msgid "Heiligabend"
+msgstr "วันคริสต์มาสอีฟ"
+
+#. New Year's Eve.
+msgid "Vortag vor Neujahr"
+msgstr "วันส่งท้ายปีเก่า"

--- a/holidays/locale/th/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/th/LC_MESSAGES/XSWX.po
@@ -10,7 +10,7 @@
 #  Website: https://github.com/vacanza/holidays
 #  License: MIT (see LICENSE file)
 #
-# SIX Swiss Exchange holidays th localization.
+# SIX Swiss Exchange (SIX) holidays th localization.
 #
 msgid ""
 msgstr ""

--- a/holidays/locale/th/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/th/LC_MESSAGES/XSWX.po
@@ -17,7 +17,7 @@ msgstr ""
 "Project-Id-Version: Holidays 0.101\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2026-07-11 00:25+0000\n"
-"PO-Revision-Date: 2026-07-12 12:10+0000\n"
+"PO-Revision-Date: 2026-07-12 13:15+0000\n"
 "Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: th\n"
@@ -27,7 +27,7 @@ msgstr ""
 "Generated-By: Lingva 5.0.6\n"
 "X-Source-Language: de\n"
 
-#. Saint Berchtold's Day
+#. Saint Berchtold's Day.
 msgid "Berchtoldstag"
 msgstr "วันสมโภชนักบุญแบร์กโทลด์"
 

--- a/holidays/locale/th/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/th/LC_MESSAGES/XSWX.po
@@ -37,4 +37,4 @@ msgstr "วันคริสต์มาสอีฟ"
 
 #. New Year's Eve.
 msgid "Vortag vor Neujahr"
-msgstr "วันส่งท้ายปีเก่า"
+msgstr "วันสิ้นปี"

--- a/holidays/locale/uk/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/uk/LC_MESSAGES/XSWX.po
@@ -10,7 +10,7 @@
 #  Website: https://github.com/vacanza/holidays
 #  License: MIT (see LICENSE file)
 #
-# SIX Swiss Exchange holidays uk localization.
+# SIX Swiss Exchange (SIX) holidays uk localization.
 #
 msgid ""
 msgstr ""

--- a/holidays/locale/uk/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/uk/LC_MESSAGES/XSWX.po
@@ -17,7 +17,7 @@ msgstr ""
 "Project-Id-Version: Holidays 0.101\n"
 "Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
 "POT-Creation-Date: 2026-07-11 00:25+0000\n"
-"PO-Revision-Date: 2026-07-12 12:10+0000\n"
+"PO-Revision-Date: 2026-07-12 13:15+0000\n"
 "Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
 "Language-Team: Holidays Localization Team\n"
 "Language: uk\n"
@@ -27,7 +27,7 @@ msgstr ""
 "Generated-By: Lingva 5.0.6\n"
 "X-Source-Language: de\n"
 
-#. Saint Berchtold's Day
+#. Saint Berchtold's Day.
 msgid "Berchtoldstag"
 msgstr "День Святого Бертольда"
 

--- a/holidays/locale/uk/LC_MESSAGES/XSWX.po
+++ b/holidays/locale/uk/LC_MESSAGES/XSWX.po
@@ -1,0 +1,40 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see CONTRIBUTORS file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/holidays
+#  License: MIT (see LICENSE file)
+#
+# SIX Swiss Exchange holidays uk localization.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Holidays 0.101\n"
+"Report-Msgid-Bugs-To: l10n@vacanza.dev\n"
+"POT-Creation-Date: 2026-07-11 00:25+0000\n"
+"PO-Revision-Date: 2026-07-12 12:10+0000\n"
+"Last-Translator: Paresh Joshi <pareshjoshij@gmail.com>\n"
+"Language-Team: Holidays Localization Team\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Lingva 5.0.6\n"
+"X-Source-Language: de\n"
+
+#. Saint Berchtold's Day
+msgid "Berchtoldstag"
+msgstr "День Святого Бертольда"
+
+#. Christmas Eve.
+msgid "Heiligabend"
+msgstr "Святвечір"
+
+#. New Year's Eve.
+msgid "Vortag vor Neujahr"
+msgstr "Переддень Нового року"

--- a/holidays/observed_holiday_base.py
+++ b/holidays/observed_holiday_base.py
@@ -115,6 +115,7 @@ SAT_SUN_TO_NEXT_TUE = ObservedRule({SAT: +3, SUN: +2})
 SAT_SUN_TO_NEXT_WED = ObservedRule({SAT: +4, SUN: +3})
 SAT_SUN_TO_NEXT_MON_TUE = ObservedRule({SAT: +2, SUN: +2})
 SAT_SUN_TO_NEXT_WORKDAY = ObservedRule({SAT: +7, SUN: +7})
+SAT_SUN_TO_NONE = ObservedRule({SAT: None, SUN: None})
 
 
 class ObservedHolidayBase(HolidayBase):

--- a/holidays/registry.py
+++ b/holidays/registry.py
@@ -300,6 +300,7 @@ FINANCIAL: RegistryDict = {
     "ny_stock_exchange": ("NewYorkStockExchange", "XNYS", "NYSE"),
     "shanghai_stock_exchange": ("ShanghaiStockExchange", "XSHG", "SSE"),
     "shenzhen_stock_exchange": ("ShenzhenStockExchange", "XSHE", "SZSE"),
+    "six_swiss_exchange": ("SIXSwissExchange", "XSWX", "SIX"),
     "toronto_stock_exchange": ("TorontoStockExchange", "XTSE", "TSX"),
 }
 

--- a/tests/financial/test_six_swiss_exchange.py
+++ b/tests/financial/test_six_swiss_exchange.py
@@ -12,7 +12,7 @@
 
 from unittest import TestCase
 
-from holidays.financial.six_swiss_exchange import SIXSwissExchange, XSWX, SIX
+from holidays.financial.six_swiss_exchange import SIXSwissExchange
 from tests.common import CommonFinancialTests
 
 
@@ -24,12 +24,6 @@ class TestSIXSwissExchange(CommonFinancialTests, TestCase):
     def test_code(self):
         self.assertTrue(hasattr(self.holidays, "market"))
         self.assertIsNone(getattr(self.holidays, "country", None))
-
-    def test_market_aliases(self):
-        self.assertAliases(SIXSwissExchange, XSWX, SIX)
-
-    def test_no_holidays(self):
-        self.assertNoHolidays(SIXSwissExchange(years=1999))
 
     def test_berchtolds_day(self):
         name = "Berchtoldstag"

--- a/tests/financial/test_six_swiss_exchange.py
+++ b/tests/financial/test_six_swiss_exchange.py
@@ -19,6 +19,7 @@ from tests.common import CommonFinancialTests
 class TestSIXSwissExchange(CommonFinancialTests, TestCase):
     @classmethod
     def setUpClass(cls):
+        cls.full_range = range(2000, 2027)
         super().setUpClass(SIXSwissExchange)
 
     def test_code(self):
@@ -27,7 +28,6 @@ class TestSIXSwissExchange(CommonFinancialTests, TestCase):
 
     def test_berchtolds_day(self):
         name = "Berchtoldstag"
-        self.full_range = range(2000, 2027)
         years_absent = {2000, 2005, 2010, 2011, 2016, 2021, 2022}
         self.assertNoHolidayName(name, years_absent)
         self.assertHolidayName(
@@ -36,7 +36,6 @@ class TestSIXSwissExchange(CommonFinancialTests, TestCase):
 
     def test_christmas_eve(self):
         name = "Heiligabend"
-        self.full_range = range(2000, 2027)
         years_absent = {2000, 2005, 2006, 2011, 2016, 2017, 2022, 2023}
         self.assertNoHolidayName(name, years_absent)
         self.assertHolidayName(
@@ -45,7 +44,6 @@ class TestSIXSwissExchange(CommonFinancialTests, TestCase):
 
     def test_new_years_eve(self):
         name = "Vortag vor Neujahr"
-        self.full_range = range(2000, 2027)
         years_absent = {2000, 2005, 2006, 2011, 2016, 2017, 2022, 2023}
         self.assertNoHolidayName(name, years_absent)
         self.assertHolidayName(
@@ -150,7 +148,7 @@ class TestSIXSwissExchange(CommonFinancialTests, TestCase):
             ("2024-12-24", "วันคริสต์มาสอีฟ"),
             ("2024-12-25", "วันคริสต์มาส"),
             ("2024-12-26", "วันสมโภชนักบุญสเตเฟน"),
-            ("2024-12-31", "วันส่งท้ายปีเก่า"),
+            ("2024-12-31", "วันสิ้นปี"),
         )
 
     def test_l10n_uk(self):

--- a/tests/financial/test_six_swiss_exchange.py
+++ b/tests/financial/test_six_swiss_exchange.py
@@ -27,47 +27,29 @@ class TestSIXSwissExchange(CommonFinancialTests, TestCase):
 
     def test_berchtolds_day(self):
         name = "Berchtoldstag"
-        self.assertNonObservedHolidayName(name, (f"{year}-01-02" for year in self.full_range))
+        self.full_range = range(2000, 2027)
+        years_absent = {2000, 2005, 2010, 2011, 2016, 2021, 2022}
+        self.assertNoHolidayName(name, years_absent)
         self.assertHolidayName(
-            name,
-            "2020-01-02",
-            "2023-01-02",
-            "2024-01-02",
-            "2025-01-02",
-        )
-        self.assertNoHoliday(
-            "2021-01-02",
-            "2022-01-02",
+            name, (year for year in self.full_range if year not in years_absent)
         )
 
     def test_christmas_eve(self):
         name = "Heiligabend"
-        self.assertNonObservedHolidayName(name, (f"{year}-12-24" for year in self.full_range))
+        self.full_range = range(2000, 2027)
+        years_absent = {2000, 2005, 2006, 2011, 2016, 2017, 2022, 2023}
+        self.assertNoHolidayName(name, years_absent)
         self.assertHolidayName(
-            name,
-            "2020-12-24",
-            "2021-12-24",
-            "2024-12-24",
-            "2025-12-24",
-        )
-        self.assertNoHoliday(
-            "2022-12-24",
-            "2023-12-24",
+            name, (year for year in self.full_range if year not in years_absent)
         )
 
     def test_new_years_eve(self):
         name = "Vortag vor Neujahr"
-        self.assertNonObservedHolidayName(name, (f"{year}-12-31" for year in self.full_range))
+        self.full_range = range(2000, 2027)
+        years_absent = {2000, 2005, 2006, 2011, 2016, 2017, 2022, 2023}
+        self.assertNoHolidayName(name, years_absent)
         self.assertHolidayName(
-            name,
-            "2020-12-31",
-            "2021-12-31",
-            "2024-12-31",
-            "2025-12-31",
-        )
-        self.assertNoHoliday(
-            "2022-12-31",
-            "2023-12-31",
+            name, (year for year in self.full_range if year not in years_absent)
         )
 
     def test_2025(self):

--- a/tests/financial/test_six_swiss_exchange.py
+++ b/tests/financial/test_six_swiss_exchange.py
@@ -1,0 +1,195 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see CONTRIBUTORS file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/holidays
+#  License: MIT (see LICENSE file)
+
+from unittest import TestCase
+
+from holidays.financial.six_swiss_exchange import SIXSwissExchange, XSWX, SIX
+from tests.common import CommonFinancialTests
+
+
+class TestSIXSwissExchange(CommonFinancialTests, TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass(SIXSwissExchange)
+
+    def test_code(self):
+        self.assertTrue(hasattr(self.holidays, "market"))
+        self.assertIsNone(getattr(self.holidays, "country", None))
+
+    def test_market_aliases(self):
+        self.assertAliases(SIXSwissExchange, XSWX, SIX)
+
+    def test_no_holidays(self):
+        self.assertNoHolidays(SIXSwissExchange(years=1999))
+
+    def test_berchtolds_day(self):
+        name = "Berchtoldstag"
+        self.assertNonObservedHolidayName(name, (f"{year}-01-02" for year in self.full_range))
+        self.assertHolidayName(
+            name,
+            "2020-01-02",
+            "2023-01-02",
+            "2024-01-02",
+            "2025-01-02",
+        )
+        self.assertNoHoliday(
+            "2021-01-02",
+            "2022-01-02",
+        )
+
+    def test_christmas_eve(self):
+        name = "Heiligabend"
+        self.assertNonObservedHolidayName(name, (f"{year}-12-24" for year in self.full_range))
+        self.assertHolidayName(
+            name,
+            "2020-12-24",
+            "2021-12-24",
+            "2024-12-24",
+            "2025-12-24",
+        )
+        self.assertNoHoliday(
+            "2022-12-24",
+            "2023-12-24",
+        )
+
+    def test_new_years_eve(self):
+        name = "Vortag vor Neujahr"
+        self.assertNonObservedHolidayName(name, (f"{year}-12-31" for year in self.full_range))
+        self.assertHolidayName(
+            name,
+            "2020-12-31",
+            "2021-12-31",
+            "2024-12-31",
+            "2025-12-31",
+        )
+        self.assertNoHoliday(
+            "2022-12-31",
+            "2023-12-31",
+        )
+
+    def test_2025(self):
+        self.assertHolidaysInYear(
+            2025,
+            ("2025-01-01", "Neujahrstag"),
+            ("2025-01-02", "Berchtoldstag"),
+            ("2025-04-18", "Karfreitag"),
+            ("2025-04-21", "Ostermontag"),
+            ("2025-05-01", "Tag der Arbeit"),
+            ("2025-05-29", "Auffahrt"),
+            ("2025-06-09", "Pfingstmontag"),
+            ("2025-08-01", "Nationalfeiertag"),
+            ("2025-12-24", "Heiligabend"),
+            ("2025-12-25", "Weihnachten"),
+            ("2025-12-26", "Stephanstag"),
+            ("2025-12-31", "Vortag vor Neujahr"),
+        )
+
+    def test_l10n_de(self):
+        self.assertLocalizedHolidays(
+            ("2024-01-01", "Neujahrstag"),
+            ("2024-01-02", "Berchtoldstag"),
+            ("2024-03-29", "Karfreitag"),
+            ("2024-04-01", "Ostermontag"),
+            ("2024-05-01", "Tag der Arbeit"),
+            ("2024-05-09", "Auffahrt"),
+            ("2024-05-20", "Pfingstmontag"),
+            ("2024-08-01", "Nationalfeiertag"),
+            ("2024-12-24", "Heiligabend"),
+            ("2024-12-25", "Weihnachten"),
+            ("2024-12-26", "Stephanstag"),
+            ("2024-12-31", "Vortag vor Neujahr"),
+        )
+
+    def test_l10n_en_us(self):
+        self.assertLocalizedHolidays(
+            "en_US",
+            ("2024-01-01", "New Year's Day"),
+            ("2024-01-02", "Saint Berchtold's Day"),
+            ("2024-03-29", "Good Friday"),
+            ("2024-04-01", "Easter Monday"),
+            ("2024-05-01", "Labor Day"),
+            ("2024-05-09", "Ascension Day"),
+            ("2024-05-20", "Pentecost Monday"),
+            ("2024-08-01", "National Day"),
+            ("2024-12-24", "Christmas Eve"),
+            ("2024-12-25", "Christmas Day"),
+            ("2024-12-26", "Saint Stephen's Day"),
+            ("2024-12-31", "New Year's Eve"),
+        )
+
+    def test_l10n_fr(self):
+        self.assertLocalizedHolidays(
+            "fr",
+            ("2024-01-01", "Nouvel An"),
+            ("2024-01-02", "Saint-Berchtold"),
+            ("2024-03-29", "Vendredi saint"),
+            ("2024-04-01", "Lundi de Pâques"),
+            ("2024-05-01", "Fête du Travail"),
+            ("2024-05-09", "Ascension"),
+            ("2024-05-20", "Lundi de Pentecôte"),
+            ("2024-08-01", "Fête nationale"),
+            ("2024-12-24", "Veille de Noël"),
+            ("2024-12-25", "Noël"),
+            ("2024-12-26", "Saint-Étienne"),
+            ("2024-12-31", "Réveillon de la Saint-Sylvestre"),
+        )
+
+    def test_l10n_it(self):
+        self.assertLocalizedHolidays(
+            "it",
+            ("2024-01-01", "Capodanno"),
+            ("2024-01-02", "Giorno di Bertoldo"),
+            ("2024-03-29", "Venerdì Santo"),
+            ("2024-04-01", "Lunedì dell'Angelo"),
+            ("2024-05-01", "Festa del lavoro"),
+            ("2024-05-09", "Ascensione di Gesù"),
+            ("2024-05-20", "Lunedì di Pentecoste"),
+            ("2024-08-01", "Festa nazionale"),
+            ("2024-12-24", "Vigilia di Natale"),
+            ("2024-12-25", "Natale"),
+            ("2024-12-26", "Giorno di Santo Stefano"),
+            ("2024-12-31", "Vigilia di Capodanno"),
+        )
+
+    def test_l10n_th(self):
+        self.assertLocalizedHolidays(
+            "th",
+            ("2024-01-01", "วันขึ้นปีใหม่"),
+            ("2024-01-02", "วันสมโภชนักบุญแบร์กโทลด์"),
+            ("2024-03-29", "วันศุกร์ประเสริฐ"),
+            ("2024-04-01", "วันจันทร์อีสเตอร์"),
+            ("2024-05-01", "วันแรงงาน"),
+            ("2024-05-09", "วันสมโภชพระเยซูเจ้าเสด็จขึ้นสวรรค์"),
+            ("2024-05-20", "วันจันทร์หลังวันสมโภชพระจิตเจ้า"),
+            ("2024-08-01", "วันชาติสวิตเซอร์แลนด์"),
+            ("2024-12-24", "วันคริสต์มาสอีฟ"),
+            ("2024-12-25", "วันคริสต์มาส"),
+            ("2024-12-26", "วันสมโภชนักบุญสเตเฟน"),
+            ("2024-12-31", "วันส่งท้ายปีเก่า"),
+        )
+
+    def test_l10n_uk(self):
+        self.assertLocalizedHolidays(
+            "uk",
+            ("2024-01-01", "Новий рік"),
+            ("2024-01-02", "День Святого Бертольда"),
+            ("2024-03-29", "Страсна пʼятниця"),
+            ("2024-04-01", "Великодній понеділок"),
+            ("2024-05-01", "День праці"),
+            ("2024-05-09", "Вознесіння Господнє"),
+            ("2024-05-20", "Другий день Пʼятидесятниці"),
+            ("2024-08-01", "Національне свято"),
+            ("2024-12-24", "Святвечір"),
+            ("2024-12-25", "Різдво Христове"),
+            ("2024-12-26", "День Святого Стефана"),
+            ("2024-12-31", "Переддень Нового року"),
+        )


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->


This PR adds the holidays for the SIX Swiss Exchange (XSWX) financial calendar and l10n support.
Part of GSoC (#3424)

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [x] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
