### PR TITLE
Update Canada holidays: add observed rule for National Day for Truth and Reconciliation in BC

### DIFF
--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -258,8 +258,10 @@ class Canada(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
             self._add_holiday_1st_mon_of_aug(tr("British Columbia Day"))
 
         if self._year >= 2023:
-            # National Day for Truth and Reconciliation.
-            self._add_holiday_sep_30(tr("National Day for Truth and Reconciliation"))
+            self._add_observed(
+                # National Day for Truth and Reconciliation.
+                self._add_holiday_sep_30(tr("National Day for Truth and Reconciliation"))
+            )
 
         self._add_thanksgiving_day()
 

--- a/tests/countries/test_canada.py
+++ b/tests/countries/test_canada.py
@@ -258,6 +258,14 @@ class TestCanada(CommonCountryTests, TestCase):
             self.assertNoNonObservedHoliday(self.subdiv_holidays_non_observed[subdiv], obs_dts)
 
         obs_dts = (
+            "2023-10-02",
+            "2028-10-02",
+            "2029-10-01",
+        )
+        self.assertSubdivBcHolidayName(name_observed, obs_dts)
+        self.assertNoSubdivBcNonObservedHoliday(obs_dts)
+
+        obs_dts = (
             "2028-10-02",
             "2029-10-01",
         )


### PR DESCRIPTION
## Proposed change

Fixes #1492.

National Day for Truth and Reconciliation has been a **statutory holiday in British Columbia since 2023** (National Day for Truth and Reconciliation Act, 2023, royal assent 2023-03-09), but the BC entry lacked an observance rule, so no day in lieu was produced when Sep 30 falls on a weekend. As documented in the issue (and requested by a maintainer there: "we'll need to add an observance rule for that"), BC statutory holidays are observed on the following working day — e.g. 2023-09-30 was a Saturday and the day off was Monday 2023-10-02.

Change: wrap the BC NDTR entry in `_add_observed(...)`, matching the existing federal handling of the same holiday.

Verified:
- `Canada(subdiv="BC")` now yields `2023-10-02`, `2028-10-02` (Sep 30 = Sat) and `2029-10-01` (Sep 30 = Sun) as "National Day for Truth and Reconciliation (observed)"; nothing extra with `observed=False`.
- Extended `test_national_day_for_truth_and_reconciliation` with a BC observed block (mirroring the existing MB block); it fails on `dev` and passes with this change.
- Full `test_canada.py` suite passes (46 passed); ruff clean.

## Type of change

- [x] Existing holiday details update (add observance rule for an existing entity)

## Checklist

- [x] I've followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md)
- [x] This PR is filed against the `dev` branch
- [x] Tests updated