### PR TITLE
South Korea: apply substitute holiday to reinstated Constitution Day (#3285)

### DIFF
--- a/holidays/countries/south_korea.py
+++ b/holidays/countries/south_korea.py
@@ -198,7 +198,9 @@ class SouthKorea(
 
         if self._year <= 2007 or self._year >= 2026:
             # Constitution Day.
-            self._add_holiday_jul_17(tr("제헌절"))
+            # Reinstated from 2026 under the alternative (substitute) holiday
+            # system, so it observes a substitute day when falling on a weekend.
+            append_observed(self._add_holiday_jul_17(tr("제헌절")), 2026)
 
         # Liberation Day.
         append_observed(self._add_holiday_aug_15(tr("광복절")), 2021)

--- a/tests/countries/test_south_korea.py
+++ b/tests/countries/test_south_korea.py
@@ -360,7 +360,10 @@ class TestSouthKorea(CommonCountryTests, TestCase):
             ),
         )
         self.assertNoHolidayName(name, range(2008, 2026))
-        self.assertHolidayName(f"{name} 대체 휴일", "1960-07-18")
+        # Substitute holiday: reinstated Constitution Day observes the modern
+        # alternative-holiday system from 2026 (2027-07-17 is a Saturday).
+        self.assertHolidayName(f"{name} 대체 휴일", "1960-07-18", "2027-07-19")
+        self.assertNoHolidayName(f"{name} 대체 휴일", range(2008, 2027))
 
     def test_liberation_day(self):
         name = "광복절"


### PR DESCRIPTION
### Proposed change

Closes #3285.

Constitution Day (제헌절, 17 July) was reinstated as a public holiday effective **2026-05-11** by the 2026 amendment to the Public Holidays Act (already cited in the module references), and is explicitly **subject to the alternative (substitute) holiday system**. The code added the day back for `year >= 2026` but without the observed/substitute rule, so no substitute day was generated when it falls on a weekend.

This wraps the 17 July add in `append_observed(..., 2026)`, matching how Liberation Day / National Foundation Day / Hangul Day apply their substitute rule.

### Behaviour (verified)

| Year | 17 Jul | Result |
|------|--------|--------|
| 2026 | Friday | Constitution Day only (no substitute) |
| 2027 | **Saturday** | Constitution Day + **alternative holiday 2027-07-19 (Mon)** |
| 2028 | Monday | Constitution Day only |

`since=2026` means pre-2008 Constitution Day is unaffected.

### Source

Already in the module references: *Public Holidays Act (2026 Amendment)* — `law.go.kr` `lsiSeq=283311`. Corroborated by [The Korea Herald](https://www.koreaherald.com/article/10665867) and [The Korea Times](https://www.koreatimes.co.kr/southkorea/20260203/constitution-day-to-be-reinstated-as-public-holiday-this-year).

### Checklist

- [x] Added substitute assertions to `test_constitution_day` (`2027-07-19`; none in 2008–2026). Full `tests/countries/test_south_korea.py` passes (33 passed).
- [x] `ruff` clean; commit signed off (DCO).