### PR TITLE
Update Ghana holidays: add 2026 special public holidays

### DIFF
--- a/holidays/countries/ghana.py
+++ b/holidays/countries/ghana.py
@@ -10,7 +10,13 @@
 #  Website: https://github.com/vacanza/holidays
 #  License: MIT (see LICENSE file)
 
-from holidays.groups import ChristianHolidays, InternationalHolidays, IslamicHolidays
+from holidays.calendars.gregorian import JAN, JUL
+from holidays.groups import (
+    ChristianHolidays,
+    InternationalHolidays,
+    IslamicHolidays,
+    StaticHolidays,
+)
 from holidays.observed_holiday_base import (
     ObservedHolidayBase,
     SAT_SUN_TO_NEXT_MON,
@@ -18,7 +24,13 @@ from holidays.observed_holiday_base import (
 )
 
 
-class Ghana(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, IslamicHolidays):
+class Ghana(
+    ObservedHolidayBase,
+    ChristianHolidays,
+    InternationalHolidays,
+    IslamicHolidays,
+    StaticHolidays,
+):
     """Ghana holidays.
 
     References:
@@ -42,6 +54,7 @@ class Ghana(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Islam
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         IslamicHolidays.__init__(self, show_estimated=islamic_show_estimated)
+        StaticHolidays.__init__(self, cls=GhanaStaticHolidays)
         kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
@@ -101,3 +114,28 @@ class GH(Ghana):
 
 class GHA(Ghana):
     pass
+
+
+class GhanaStaticHolidays:
+    """Ghana special holidays.
+
+    When a statutory public holiday falls on a weekday, the President may, by
+    Executive Instrument under Section 2 of the Public Holidays and Commemorative
+    Days Act (Act 601), declare the following Friday a public holiday.
+
+    References:
+        * [Constitution Day observed 2026](https://www.mint.gov.gh/declaration-of-friday-9th-january2026-as-a-public-holiday/)
+        * [Republic Day observed 2026](https://www.mint.gov.gh/declaration-of-friday-3rd-july-2026-as-a-public-holiday/)
+    """
+
+    # Constitution Day.
+    constitution_day = "Constitution Day"
+    # Republic Day.
+    republic_day = "Republic Day"
+
+    special_public_holidays = {
+        2026: (
+            (JAN, 9, constitution_day),
+            (JUL, 3, republic_day),
+        ),
+    }

--- a/tests/countries/test_ghana.py
+++ b/tests/countries/test_ghana.py
@@ -33,6 +33,13 @@ class TestGhana(CommonCountryTests, TestCase):
         self.assertHolidayName(f"{name} (observed)", obs_dts)
         self.assertNoNonObservedHoliday(obs_dts)
 
+    def test_2026_substitute_holidays(self):
+        # Executive Instruments moving 2026 weekday holidays to Friday.
+        self.assertHoliday("2026-01-09", "2026-07-03")
+        self.assertHolidayName("Constitution Day", "2026-01-09")
+        self.assertHolidayName("Republic Day", "2026-07-03")
+        self.assertNoHolidayName("Republic Day", range(2019, 2026), range(2027, 2050))
+
     def test_constitution_day(self):
         name = "Constitution Day"
         self.assertHolidayName(name, (f"{year}-01-07" for year in range(2019, self.end_year)))


### PR DESCRIPTION
### Proposed change

Under Section 2 of Ghana's Public Holidays and Commemorative Days Act (Act 601), when a statutory holiday falls on a weekday the President may declare the following Friday a public holiday. For 2026, two such Executive Instruments were issued:

- **Constitution Day** (statutory Wed 7 Jan) → public holiday on **Fri 9 January 2026**
- **Republic Day** (statutory Wed 1 Jul) → public holiday on **Fri 3 July 2026**

Adds both via a new `GhanaStaticHolidays` class.

### Source

- Ghana Ministry of the Interior — *Declaration of Friday, 9th January 2026 as a Public Holiday* and *Declaration of Friday, 3rd July 2026 as a Public Holiday* (mint.gov.gh); Graphic Online / GNA.

### Checklist

- [x] `2026-01-09` = "Constitution Day", `2026-07-03` = "Republic Day"; absent other years.
- [x] `tests/countries/test_ghana.py` passes (23 passed); `ruff` clean.
- [x] Commit signed off (DCO).

Note: I kept the labels as plain "Constitution Day" / "Republic Day"; happy to switch to the "(observed)" convention if you'd prefer.