### PR TITLE
Update India holidays: fix 2026 Holi date in Maharashtra

### DIFF
--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -263,7 +263,7 @@ class India(
             # Maha Shivaratri.
             self._add_maha_shivaratri(tr("Maha Shivaratri"))
 
-        if self._year not in self.holi_optional_years:
+        if self._year not in self.holi_optional_years and self.subdiv != "MH":
             # Holi.
             self._add_holi(tr("Holi"))
 

--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -263,7 +263,7 @@ class India(
             # Maha Shivaratri.
             self._add_maha_shivaratri(tr("Maha Shivaratri"))
 
-        if self._year not in self.holi_optional_years and self.subdiv != "MH":
+        if self._year not in self.holi_optional_years and self._normalized_subdiv != "MH":
             # Holi.
             self._add_holi(tr("Holi"))
 

--- a/tests/countries/test_india.py
+++ b/tests/countries/test_india.py
@@ -193,6 +193,19 @@ class TestIndia(CommonCountryTests, TestCase):
             "2025-03-14",
         )
         self._assertHinduHolidayHelper(name, dts, skip_years=skip_years)
+
+        # SUBDIVS.
+        self.assertHolidayName(
+            name,
+            self.subdiv_holidays["MH"],
+            "2026-03-03",
+        )
+        self.assertNoHolidayName(
+            name,
+            self.subdiv_holidays["MH"],
+            "2026-03-04",
+        )
+
         # OPTIONAL.
         dts = (
             "2002-03-29",

--- a/tests/countries/test_india.py
+++ b/tests/countries/test_india.py
@@ -193,7 +193,6 @@ class TestIndia(CommonCountryTests, TestCase):
             "2025-03-14",
         )
         self._assertHinduHolidayHelper(name, dts, skip_years=skip_years)
-
         # OPTIONAL.
         dts = (
             "2002-03-29",
@@ -202,7 +201,6 @@ class TestIndia(CommonCountryTests, TestCase):
         self._assertHinduHolidayHelper(
             name, dts, category=OPTIONAL, skip_years=set(self.hindu_full_range) - skip_years
         )
-
         # SUBDIVS.
         self.assertSubdivMhHolidayName(name, "2026-03-03")
         self.assertNoSubdivMhHolidayName(name, "2026-03-04")

--- a/tests/countries/test_india.py
+++ b/tests/countries/test_india.py
@@ -194,18 +194,6 @@ class TestIndia(CommonCountryTests, TestCase):
         )
         self._assertHinduHolidayHelper(name, dts, skip_years=skip_years)
 
-        # SUBDIVS.
-        self.assertHolidayName(
-            name,
-            self.subdiv_holidays["MH"],
-            "2026-03-03",
-        )
-        self.assertNoHolidayName(
-            name,
-            self.subdiv_holidays["MH"],
-            "2026-03-04",
-        )
-
         # OPTIONAL.
         dts = (
             "2002-03-29",
@@ -214,6 +202,10 @@ class TestIndia(CommonCountryTests, TestCase):
         self._assertHinduHolidayHelper(
             name, dts, category=OPTIONAL, skip_years=set(self.hindu_full_range) - skip_years
         )
+
+        # SUBDIVS.
+        self.assertSubdivMhHolidayName(name, "2026-03-03")
+        self.assertNoSubdivMhHolidayName(name, "2026-03-04")
 
     def test_ram_navami(self):
         name = "Ram Navami"


### PR DESCRIPTION
## Summary

This PR fixes the **Holi holiday date for the Maharashtra (`MH`) subdivision for 2026**.

## Problem

The `holidays` library currently returns **Holi on both March 3 and March 4, 2026** for Maharashtra, while the **Government of Maharashtra officially declared March 3, 2026 as the Holi holiday**.

The holiday should be observed **only on March 3, 2026** for the Maharashtra subdivision. March 4, 2026 should not be included as a Holi holiday for Maharashtra.

As a result, applications and services relying on the `holidays` library could return an incorrect additional public holiday when querying Maharashtra holidays for 2026.

**Official Reference:**

http://mmrda.maharashtra.gov.in/en/public-holidays

## Solution

* Corrected the Maharashtra-specific Holi holiday date for **2026**.
* Ensured that Maharashtra returns **March 3, 2026** as the Holi holiday.
* Prevented the incorrect **March 4, 2026** date from being returned as a Holi holiday for the Maharashtra subdivision.
* Ensured that Holi is represented **only on March 3, 2026** for Maharashtra.
* Added/updated tests to verify the Maharashtra-specific behavior.
* Kept the change limited to Maharashtra so that Holi dates for other subdivisions are not unintentionally affected.

## How the issue was identified

I used my **HolidayLens** project to compare holiday data from the `holidays` library against authoritative holiday sources.

HolidayLens helped identify the discrepancy between the holiday dates returned by the library and the officially declared Maharashtra holiday for 2026.

**HolidayLens repository:**

https://github.com/Drona-jadhav7/HolidayLens

The project is being developed as a helper tool for identifying potential holiday-data accuracy and coverage issues in the `holidays` library.

## Why this change matters

Accurate holiday dates are important for applications and services that depend on the `holidays` library, including:

* Calendar and scheduling applications
* HR and payroll systems
* Leave and attendance management software
* Banking and financial applications
* Government and public-sector services
* Travel, booking, and event planning platforms

Ensuring that Maharashtra's officially declared Holi holiday is represented correctly improves the reliability of the library for users and applications operating in the state.

## Testing

Verified with the relevant Maharashtra and India holiday tests.

The complete test suite was also run locally and passes successfully.

The Maharashtra Holi behavior was specifically verified to ensure that:

* **March 3, 2026** is included as Holi for Maharashtra.
* **March 4, 2026** is not included as Holi for Maharashtra.
* Holi is therefore represented **only on March 3, 2026** for Maharashtra.
* Other subdivision behavior is not affected by the Maharashtra-specific fix.

## Additional Context

This issue was identified independently through **HolidayLens**, which was used to audit the `holidays` library against official holiday data.

HolidayLens is intended to help discover real-world holiday-data discrepancies that can then be investigated and fixed upstream in the `holidays` library.
