### PR TITLE
Fix unbounded functools.cache retention in Burmese and Thai calendars

### DIFF
--- a/holidays/calendars/burmese.py
+++ b/holidays/calendars/burmese.py
@@ -122,6 +122,8 @@ class _BurmeseLunisolar:
 
         return date(y, m, d)
 
+    # @staticmethod so functools.cache keys only on `year`. As an instance method,
+    # `self` would be part of the key, which retains instances and grows the cache unboundedly.
     @staticmethod
     @cache
     def _get_start_date(year: int) -> date | None:

--- a/holidays/calendars/burmese.py
+++ b/holidays/calendars/burmese.py
@@ -122,19 +122,20 @@ class _BurmeseLunisolar:
 
         return date(y, m, d)
 
+    @staticmethod
     @cache
-    def _get_start_date(self, year: int) -> date | None:
-        if year < self.START_YEAR or year > self.END_YEAR:
+    def _get_start_date(year: int) -> date | None:
+        if year < _BurmeseLunisolar.START_YEAR or year > _BurmeseLunisolar.END_YEAR:
             return None
 
-        delta_days = 354 * (year - self.START_YEAR)
-        for iter_year in range(self.START_YEAR, year):
-            if iter_year in self.LITTLE_WATAT_YEARS_GREGORIAN:
+        delta_days = 354 * (year - _BurmeseLunisolar.START_YEAR)
+        for iter_year in range(_BurmeseLunisolar.START_YEAR, year):
+            if iter_year in _BurmeseLunisolar.LITTLE_WATAT_YEARS_GREGORIAN:
                 delta_days += 30
-            elif iter_year in self.BIG_WATAT_YEARS_GREGORIAN:
+            elif iter_year in _BurmeseLunisolar.BIG_WATAT_YEARS_GREGORIAN:
                 delta_days += 31
 
-        return _timedelta(self.START_DATE, delta_days)
+        return _timedelta(_BurmeseLunisolar.START_DATE, delta_days)
 
     def thingyan_dates(self, year: int) -> tuple[date | None, date | None]:
         """Calculate key dates of Thingyan (Myanmar New Year festival) - Akya day

--- a/holidays/calendars/thai.py
+++ b/holidays/calendars/thai.py
@@ -294,6 +294,8 @@ class _ThaiLunisolar:
                 f"Unknown calendar name: {calendar}. Use `KHMER_CALENDAR` or `THAI_CALENDAR`."
             )
 
+    # @staticmethod so functools.cache keys only on `year`. As an instance method,
+    # `self` would be part of the key, which retains instances and grows the cache unboundedly.
     @staticmethod
     @cache
     def _get_start_date(year: int) -> date | None:
@@ -322,6 +324,8 @@ class _ThaiLunisolar:
 
         return _timedelta(_ThaiLunisolar.START_DATE, delta_days)
 
+    # @staticmethod so functools.cache keys only on `year`. As an instance method,
+    # `self` would be part of the key, which retains instances and grows the cache unboundedly.
     @staticmethod
     @cache
     def buddhist_sabbath_dates(year: int) -> set[date]:
@@ -348,6 +352,8 @@ class _ThaiLunisolar:
             months.insert(7, 30)
         elif year in _ThaiLunisolar.ATHIKAWAN_YEARS_GREGORIAN:
             months[6] += 1
+        # Includes first two months of the next Thai lunar year to ensure all Buddhist Sabbaths
+        # in the Gregorian year are captured.
         months.extend([29, 30])
 
         buddhist_sabbaths: set[date] = set()

--- a/holidays/calendars/thai.py
+++ b/holidays/calendars/thai.py
@@ -294,8 +294,9 @@ class _ThaiLunisolar:
                 f"Unknown calendar name: {calendar}. Use `KHMER_CALENDAR` or `THAI_CALENDAR`."
             )
 
+    @staticmethod
     @cache
-    def _get_start_date(self, year: int) -> date | None:
+    def _get_start_date(year: int) -> date | None:
         """Calculate the start date of that particular Thai Lunar Calendar Year.
 
         This usually falls in November or December of the previous Gregorian
@@ -321,8 +322,9 @@ class _ThaiLunisolar:
 
         return _timedelta(_ThaiLunisolar.START_DATE, delta_days)
 
+    @staticmethod
     @cache
-    def buddhist_sabbath_dates(self, year: int) -> set[date]:
+    def buddhist_sabbath_dates(year: int) -> set[date]:
         """Return all Buddhist Sabbath (Uposatha) days in a given Gregorian year.
 
         This function works independently of the calendar system in use,
@@ -336,7 +338,7 @@ class _ThaiLunisolar:
             A set of `date` objects representing all Buddhist Sabbath days in the specified
             Gregorian year. Returns an empty set if the year is outside the supported range.
         """
-        start_date = self._get_start_date(year)
+        start_date = _ThaiLunisolar._get_start_date(year)
         if not start_date:
             return set()
 
@@ -346,8 +348,6 @@ class _ThaiLunisolar:
             months.insert(7, 30)
         elif year in _ThaiLunisolar.ATHIKAWAN_YEARS_GREGORIAN:
             months[6] += 1
-        # Includes first two months of the next Thai lunar year to ensure all Buddhist Sabbaths
-        # in the Gregorian year are captured.
         months.extend([29, 30])
 
         buddhist_sabbaths: set[date] = set()
@@ -355,7 +355,6 @@ class _ThaiLunisolar:
         for month_days in months:
             if day_cursor.year > year:
                 break
-            # Buddhist Sabbaths: 8 Waxing, 15 Waxing, 8 Waning, 14/15 Waning.
             for offset in (7, 14, 22, month_days - 1):
                 buddhist_sabbath = _timedelta(day_cursor, offset)
                 if buddhist_sabbath.year == year:


### PR DESCRIPTION
## Proposed change
`functools.cache` keys on all arguments. `_get_start_date` (Burmese and Thai) and `buddhist_sabbath_dates` (Thai) were `@cache`'d instance methods, so `self` was part of every cache key. That retained each calendar instance in the unbounded cache and added a new entry per instance.

Make these year-only helpers `@staticmethod` + `@cache` so the cache keys only on `year`.

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->


## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Documentation update
- [ ] Test suite update
- [ ] Development process update (CI, release workflows, project configuration, internal tooling)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [ ] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [ ] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
