### PR TITLE
Update India holidays: Add Maharashtra Diwali (Balipratipada) public holiday

### DIFF
--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -783,6 +783,9 @@ class India(
         # Ganesh Chaturthi.
         self._add_ganesh_chaturthi(tr("Ganesh Chaturthi"))
 
+        # Diwali (Balipratipada).
+        self._add_govardhan_puja(tr("Diwali (Balipratipada)"))
+
     # Madhya Pradesh.
     def _populate_subdiv_mp_public_holidays(self):
         # Madhya Pradesh Foundation Day.

--- a/tests/countries/test_india.py
+++ b/tests/countries/test_india.py
@@ -754,6 +754,21 @@ class TestIndia(CommonCountryTests, TestCase):
         self.assertNoSubdivMhHoliday(dts_vinayak)
         self.assertNoSubdivMhOptionalHoliday(dts_vinayak)
 
+    def test_bali_pratipada(self):
+        name = "Diwali (Balipratipada)"
+        dts = (
+            "2018-11-08",
+            "2019-10-28",
+            "2020-11-15",
+            "2021-11-05",
+            "2022-10-25",
+            "2023-11-13",
+            "2024-11-02",
+            "2025-10-22",
+            "2026-11-10",
+        )
+        self.assertHolidayName(name, self.subdiv_holidays["MH"], dts)
+
     def test_dussehra_saptami(self):
         name = "Dussehra (Saptami)"
         dts = (


### PR DESCRIPTION
## Summary

This PR adds **Diwali (Balipratipada)** as a **public holiday** for the
**Maharashtra (`MH`) subdivision**.

## Problem

While validating Maharashtra holiday data for 2026 using **HolidayLens**,
a discrepancy was identified between the official Maharashtra holiday
dataset and the holidays library.

The official holiday data includes **Diwali (Balipratipada)** on
**10 November 2026**, but the Maharashtra holidays generated by the
library did not include this holiday.

**Official Reference:**

http://mmrda.maharashtra.gov.in/en/public-holidays

HolidayLens was used to compare the library's output against the
official Maharashtra holiday dataset and helped identify this missing
holiday.

## Approach

The existing `_add_govardhan_puja()` helper is reused for
`Diwali (Balipratipada)` because it provides the required date
calculation for the observed Balipratipada dates.

The holiday is added only inside the Maharashtra public-holiday
population method, so it does not affect other Indian subdivisions.

The holiday name is wrapped with `tr()` so that it participates in the
library's existing localization system.

## Changes

- Added `Diwali (Balipratipada)` to Maharashtra public holidays.
- Reused the existing `_add_govardhan_puja()` helper.
- Added regression coverage for Balipratipada dates from 2018 through
  2026.

The expected dates covered by the test are:

| Year | Date |
| --- | --- |
| 2018 | November 8 |
| 2019 | October 28 |
| 2020 | November 15 |
| 2021 | November 5 |
| 2022 | October 25 |
| 2023 | November 13 |
| 2024 | November 2 |
| 2025 | October 22 |
| 2026 | November 10 |

## Localization

The new holiday name is wrapped with `tr()`:

```python
self._add_govardhan_puja(tr("Diwali (Balipratipada)"))