### PR TITLE
Update l10n test: fix duplicated entries check

### DIFF
--- a/tests/test_l10n.py
+++ b/tests/test_l10n.py
@@ -55,17 +55,17 @@ class TestLocalization(unittest.TestCase):
         for po_path in sorted(locale_dir.rglob("*.po")):
             try:
                 po_file = create_po_file(po_path, check_for_duplicates=True)
-            except ValueError as e:
+            except Exception as e:
                 # Make sure no duplicated entries added.
-                match = re.match(r"Entry (.*) already exists", str(e))
-                self.assertEqual(
-                    0,
-                    len(match.groups()),
-                    f"Entry `{match.group(1)}` already exists in {po_path}. "
-                    "Please remove the duplicate.",
-                )
-
-                raise e
+                if match := re.match(r"Entry (.*) already exists", str(e.__context__)):
+                    self.assertEqual(
+                        0,
+                        len(match.groups()),
+                        f"Entry `{match.group(1)}` already exists in {po_path}. "
+                        "Please remove the duplicate.",
+                    )
+                else:
+                    raise e
 
             missing_fields = mandatory_fields - set(po_file.metadata)
             self.assertFalse(


### PR DESCRIPTION
<!--
  Thanks for contributing to holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Proper error text output (`ValueError` exception is handled within `polib` and does not reach our code directly - https://github.com/vacanza/holidays/actions/runs/32868831034/job/97873918443#step:6:248).

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Documentation update
- [x] Test suite update
- [ ] Development process update (CI, release workflows, project configuration, internal tooling)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new `holidays` functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've read and followed the [contributing guidelines](https://github.com/vacanza/holidays/blob/dev/CONTRIBUTING.md).
- [x] I've run `make check` locally; all checks and tests passed.

<!--
  Thanks again for your contribution!
-->
