### PR TITLE
Update Canada holidays: remove Boxing Day from optional holidays in QC

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,6 +22,7 @@ Ankush Kapoor
 Anon Kangpanich
 Anthony Rose
 Anton Daitche
+Arbaz Khan
 Arjun Anandkumar
 Arkadii Yakovets
 Artem Tserekh

--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -41,6 +41,8 @@ class Canada(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
             * [Employment Standards Act, 2000](https://web.archive.org/web/20260814113906/https://www.ontario.ca/laws/statute/00e41)
             * [Proclamation of Oct 12, 2007](https://web.archive.org/web/20250906045854/https://www.ontario.ca/document/ontario-gazette-volume-140-issue-43-october-27-2007)
             * [Guide to the Employment Standards Act](https://web.archive.org/web/20250405170509/https://www.ontario.ca/document/your-guide-employment-standards-act-0/public-holidays)
+        * Quebec:
+            * [National Holiday Act, N-1.1 s. 60](https://www.legisquebec.gouv.qc.ca/fr/document/lc/N-1.1?langCont=en#se:60)
         * <https://archive.org/details/nunavut-day-designated-as-a-general-holiday-start-date>
         * <https://web.archive.org/web/20250122122256/https://www.warmuseum.ca/firstworldwar/history/after-the-war/remembrance/remembrance-day/>
         * <https://web.archive.org/web/20250428153936/https://www.thecanadianencyclopedia.ca/en/article/thanksgiving-day>
@@ -168,11 +170,14 @@ class Canada(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
             rule=SAT_SUN_TO_NEXT_MON_TUE,
         )
 
-        self._add_observed(
-            # Boxing Day.
-            self._add_christmas_day_two(tr("Boxing Day")),
-            rule=SAT_SUN_TO_NEXT_MON_TUE,
-        )
+        # Quebec N-1.1 s. 60 does not list Boxing Day.
+        # https://www.legisquebec.gouv.qc.ca/fr/document/lc/N-1.1?langCont=en#se:60
+        if self._normalized_subdiv != "QC":
+            self._add_observed(
+                # Boxing Day.
+                self._add_christmas_day_two(tr("Boxing Day")),
+                rule=SAT_SUN_TO_NEXT_MON_TUE,
+            )
 
     def _add_thanksgiving_day(self) -> None:
         """Adds Thanksgiving Day / Armistice Day.

--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -42,7 +42,7 @@ class Canada(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
             * [Proclamation of Oct 12, 2007](https://web.archive.org/web/20250906045854/https://www.ontario.ca/document/ontario-gazette-volume-140-issue-43-october-27-2007)
             * [Guide to the Employment Standards Act](https://web.archive.org/web/20250405170509/https://www.ontario.ca/document/your-guide-employment-standards-act-0/public-holidays)
         * Quebec:
-            * [National Holiday Act, N-1.1 s. 60](https://www.legisquebec.gouv.qc.ca/fr/document/lc/N-1.1?langCont=en#se:60)
+            * [National Holiday Act, N-1.1 s. 60](https://web.archive.org/web/20260312101221/https://www.legisquebec.gouv.qc.ca/fr/document/lc/N-1.1?langcont=en#se:60)
         * <https://archive.org/details/nunavut-day-designated-as-a-general-holiday-start-date>
         * <https://web.archive.org/web/20250122122256/https://www.warmuseum.ca/firstworldwar/history/after-the-war/remembrance/remembrance-day/>
         * <https://web.archive.org/web/20250428153936/https://www.thecanadianencyclopedia.ca/en/article/thanksgiving-day>
@@ -170,8 +170,6 @@ class Canada(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
             rule=SAT_SUN_TO_NEXT_MON_TUE,
         )
 
-        # Quebec N-1.1 s. 60 does not list Boxing Day.
-        # https://www.legisquebec.gouv.qc.ca/fr/document/lc/N-1.1?langCont=en#se:60
         if self._normalized_subdiv != "QC":
             self._add_observed(
                 # Boxing Day.

--- a/tests/countries/test_canada.py
+++ b/tests/countries/test_canada.py
@@ -413,6 +413,8 @@ class TestCanada(CommonCountryTests, TestCase):
                 (f"{year}-12-26" for year in self.full_range),
             )
 
+        self.assertNoSubdivQcOptionalHolidayName(name)
+
     def test_family_day(self):
         start_years = {
             "AB": 1990,


### PR DESCRIPTION
## Summary
Quebec Public + Optional was inheriting nationwide optional Boxing Day. That holiday is federal, not listed in [Quebec National Holiday Act N-1.1 s. 60](https://www.legisquebec.gouv.qc.ca/fr/document/lc/N-1.1?langCont=en#se:60).

This keeps Boxing Day on nationwide optional (and on AB/NB/NL optional, ON public) and skips it when `subdiv == "QC"`.

## Test plan
- [x] `pytest tests/countries/test_canada.py::TestCanada::test_boxing_day`

Fixes #3798

Made with [Cursor](https://cursor.com)